### PR TITLE
AAA through http does not work unless you specify HS_AAA=http in the config file

### DIFF
--- a/conf/defaults.in
+++ b/conf/defaults.in
@@ -52,7 +52,9 @@ HS_UAMALIASNAME=chilli
 #    option key $HS_RADPROXY_SECRET
 
 
-#   To alternatively use a HTTP URL for AAA instead of RADIUS:
+# To alternatively use a HTTP URL for AAA instead of RADIUS
+# Enable http for AAA and then specify the url to send the AAA Request
+# HS_AAA=http
 # HS_UAMAAAURL=http://my-site/script.php
 
 #   Put entire domains in the walled-garden with DNS inspection


### PR DESCRIPTION
AAA through http does not work unless you specify HS_AAA=http in the config file. 
This was not clear in the config file. This took me some time to figure out. 

 Just updating the config file to make it clear. 

Signed-by: Ramanathan Sivagurunathan ramzthecoder@gmail.com
