### PR TITLE
Let libcurl figure out the remote SSL protocol version.

### DIFF
--- a/src/main-proxy.c
+++ b/src/main-proxy.c
@@ -529,7 +529,7 @@ static int http_aaa_setup(struct radius_t *radius, proxy_request *req) {
     }
     
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
-    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_SSLv3);
+    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_DEFAULT);
 #endif
     
     curl_easy_setopt(curl, CURLOPT_VERBOSE, /*debug ? 1 :*/ 0);


### PR DESCRIPTION
chilli_proxy is not able to communicate when SSLv3 support is disabled at `uamaaaurl`.
