### PR TITLE
syslog, not sylog!

### DIFF
--- a/src/main-redir.c
+++ b/src/main-redir.c
@@ -306,7 +306,7 @@ static int redir_cli_write(redir_request *req, uint8_t *d, int l) {
   if (w >= 0) {
     if (w < l) {
       bcatblk(req->dbuf, d + w, l - w);
-      sylog(LOG_WARNING, "%d buffering %d - %d = %d (%d queued)", 
+      syslog(LOG_WARNING, "%d buffering %d - %d = %d (%d queued)", 
 	       errno, l, w, l-w, req->dbuf->slen);
     }
   }


### PR DESCRIPTION
Typo spotted by @matahr

	modified:   src/main-redir.c