### PR TITLE
#include debug.h from system.h

### DIFF
--- a/src/chilli.c
+++ b/src/chilli.c
@@ -20,7 +20,6 @@
 
 #include "chilli.h"
 #include "bstrlib.h"
-#include "debug.h"
 #ifdef ENABLE_MODULES
 #include "chilli_module.h"
 #endif

--- a/src/chilli.h
+++ b/src/chilli.h
@@ -22,6 +22,7 @@
 #define _CHILLI_H
 
 #include "system.h"
+#include "debug.h"
 #include "chilli_limits.h"
 #include "tun.h"
 #include "ippool.h"

--- a/src/conn.c
+++ b/src/conn.c
@@ -18,7 +18,6 @@
  */
 
 #include "chilli.h"
-#include "debug.h"
 
 #if defined(ENABLE_CHILLIPROXY) || defined(ENABLE_CHILLIRADSEC) || defined(ENABLE_CHILLIREDIR)
 

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -23,7 +23,6 @@
 #ifdef ENABLE_MODULES
 #include "chilli_module.h"
 #endif
-#include "debug.h"
 
 const uint32_t DHCP_OPTION_MAGIC = 0x63825363;
 static uint8_t bmac[PKT_ETH_ALEN] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};

--- a/src/dns.c
+++ b/src/dns.c
@@ -18,7 +18,6 @@
  */
 
 #include "chilli.h"
-#include "debug.h"
 
 #define antidnstunnel _options.dnsparanoia
 

--- a/src/garden.c
+++ b/src/garden.c
@@ -19,7 +19,6 @@
  */
 
 #include "chilli.h"
-#include "debug.h"
 
 #ifdef HAVE_PATRICIA
 struct node_pass_through_list {

--- a/src/main-opt.c
+++ b/src/main-opt.c
@@ -23,7 +23,6 @@
 #include "cmdline.h"
 #include "system.h"
 #include "chilli.h"
-#include "debug.h"
 
 struct options_t _options;
 

--- a/src/main-proxy.c
+++ b/src/main-proxy.c
@@ -21,7 +21,6 @@
 #define MAIN_FILE
 
 #include "chilli.h"
-#include "debug.h"
 
 #ifdef USING_CURL
 #include <curl/curl.h>

--- a/src/main-redir.c
+++ b/src/main-redir.c
@@ -19,7 +19,6 @@
 #define MAIN_FILE
 
 #include "chilli.h"
-#include "debug.h"
 
 struct options_t _options;
 

--- a/src/mssl.c
+++ b/src/mssl.c
@@ -42,7 +42,6 @@
 
 #include "chilli.h"
 #include "ssl.h"
-#include "debug.h"
 
 #define SSL_SOCKET_EOF  0x0001
 #define SSL_SOCKET_CLOSE_NOTIFY  0x0002

--- a/src/net.c
+++ b/src/net.c
@@ -19,7 +19,6 @@
  */
 
 #include "chilli.h"
-#include "debug.h"
 #ifdef ENABLE_MODULES
 #include "chilli_module.h"
 #endif

--- a/src/redir.c
+++ b/src/redir.c
@@ -20,7 +20,6 @@
 
 #include "system.h"
 #include "chilli.h"
-#include "debug.h"
 #ifdef ENABLE_MODULES
 #include "chilli_module.h"
 #endif

--- a/src/safe.c
+++ b/src/safe.c
@@ -19,7 +19,6 @@
  */
 
 #include "chilli.h"
-#include "debug.h"
 #ifdef ENABLE_MODULES
 #include "chilli_module.h"
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19,7 +19,6 @@
 #include "system.h"
 #ifdef HAVE_SSL
 #include "chilli.h"
-#include "debug.h"
 
 static int openssl_init = 0;
 static openssl_env * sslenv_svr = 0;

--- a/src/tun.c
+++ b/src/tun.c
@@ -29,7 +29,6 @@
  */
 
 #include "chilli.h"
-#include "debug.h"
 #ifdef ENABLE_MULTIROUTE
 #include "rtmon.h"
 extern struct rtmon_t _rtmon;


### PR DESCRIPTION
Too many C files forgot to include debug.h, which resulted in `_debug_` never to be `#define`d, and many debug statements to do nothing.