### PR TITLE
Do not force -O2 compilation

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,7 @@ iphash.c lookup.c system.h util.c options.c statusfile.c conn.c sig.c \
 garden.c dns.c session.c pkt.c chksum.c net.c safe.c
 
 AM_CFLAGS = -D_GNU_SOURCE -Wall -Werror -fno-builtin -fno-strict-aliasing \
-  -O2 -fomit-frame-pointer -funroll-loops -pipe -I$(top_builddir)/bstring \
+  -fomit-frame-pointer -funroll-loops -pipe -I$(top_builddir)/bstring \
  -DDEFCHILLICONF='"$(sysconfdir)/chilli.conf"'\
  -DDEFPIDFILE='"$(localstatedir)/run/chilli.pid"'\
  -DDEFSTATEDIR='"$(localstatedir)/run"'\


### PR DESCRIPTION
This should be left to the configure script. This makes sane debugging of chilli possible by allowing compilation without optimisation.