### PR TITLE
Use the AM_PROG_CC_C_O macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 # Checks for programs.
 AC_PROG_CC
+AC_PROG_CC_C_O
 
 #JJAKO Check for libtool
 AC_PROG_LIBTOOL


### PR DESCRIPTION
this fixes bootstrapping on OpenBSD which broke after the removal of files which were regenerated during this process.
	modified:   configure.ac