### PR TITLE
Switch from safe_strncpy() to strlcpy()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,7 @@ AC_FUNC_MEMCMP
 AC_FUNC_SELECT_ARGTYPES
 AC_CHECK_FUNCS([gethostbyname getprotoent gettimeofday inet_ntoa \
 memset select socket strdup strerror strstr strtol getline dirname \
-glob getaddrinfo getnameinfo getifaddrs sysinfo])
+glob getaddrinfo getnameinfo getifaddrs sysinfo strlcpy])
 AC_CHECK_LIB(resolv, res_init)
 
 AC_ARG_ENABLE(chilliquery, [AC_HELP_STRING([--disable-chilliquery],[Disable chilli_query])], 
@@ -777,6 +777,8 @@ fi
 
 
 AC_CHECK_LIB(rt, clock_gettime)
+
+AM_CONDITIONAL([HAVE_STRLCPY], [test "x$ac_cv_func_strlcpy" = xyes])
 
 AC_ARG_ENABLE(config,
  [  --enable-config=file],

--- a/extern/strlcpy.c
+++ b/extern/strlcpy.c
@@ -1,0 +1,50 @@
+/*	$OpenBSD: strlcpy.c,v 1.12 2015/01/15 03:54:12 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ */
+size_t
+strlcpy(char *dst, const char *src, size_t dsize)
+{
+	const char *osrc = src;
+	size_t nleft = dsize;
+
+	/* Copy as many bytes as will fit. */
+	if (nleft != 0) {
+		while (--nleft != 0) {
+			if ((*dst++ = *src++) == '\0')
+				break;
+		}
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src. */
+	if (nleft == 0) {
+		if (dsize != 0)
+			*dst = '\0';		/* NUL-terminate dst */
+		while (*src++)
+			;
+	}
+
+	return(src - osrc - 1);	/* count does not include NUL */
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -175,6 +175,10 @@ chilliinclude_HEADERS += chilli_module.h
 AM_CFLAGS += -DDEFLIBDIR='"$(libdir)/coova-chilli"'
 endif
 
+if !HAVE_STRLCPY
+libchilli_la_SOURCES += ../extern/strlcpy.c
+endif
+
 CMDLINE = cmdline.ggo
 if WITH_CONFIG
 CMDLINE += `[ -e ../../cmdline.ggo ] && echo ../../cmdline.ggo`

--- a/src/chilli.c
+++ b/src/chilli.c
@@ -720,7 +720,7 @@ void set_env(char *name, char type, void *value, int len) {
   switch(type) {
 
   case VAL_IN_ADDR:
-    safe_strncpy(s, inet_ntoa(*(struct in_addr *)value), sizeof(s));
+    strlcpy(s, inet_ntoa(*(struct in_addr *)value), sizeof(s));
     v = s;
     break;
 
@@ -1553,11 +1553,11 @@ int static auth_radius(struct app_conn_t *appconn,
 
     service_type = RADIUS_SERVICE_TYPE_FRAMED;
 
-    safe_strncpy(appconn->s_state.redir.username, mac, USERNAMESIZE);
+    strlcpy(appconn->s_state.redir.username, mac, USERNAMESIZE);
 
     if (_options.macsuffix) {
       size_t ulen = strlen(appconn->s_state.redir.username);
-      safe_strncpy(appconn->s_state.redir.username + ulen,
+      strlcpy(appconn->s_state.redir.username + ulen,
 		   _options.macsuffix, USERNAMESIZE - ulen);
     }
 
@@ -1565,7 +1565,7 @@ int static auth_radius(struct app_conn_t *appconn,
 
   } else {
 
-    safe_strncpy(appconn->s_state.redir.username, username, USERNAMESIZE);
+    strlcpy(appconn->s_state.redir.username, username, USERNAMESIZE);
 
   }
 
@@ -2120,7 +2120,7 @@ int dnprot_reject(struct app_conn_t *appconn) {
   case DNPROT_MAC:
     /* remove the username since we're not logged in */
     if (!appconn->s_state.authenticated)
-      safe_strncpy(appconn->s_state.redir.username, "-", USERNAMESIZE);
+      strlcpy(appconn->s_state.redir.username, "-", USERNAMESIZE);
 
     if (!(dhcpconn = (struct dhcp_conn_t *)appconn->dnlink)) {
       syslog(LOG_ERR, "No downlink protocol");
@@ -3783,7 +3783,7 @@ session_disconnect(struct app_conn_t *appconn,
 	  appconn->hisip.s_addr;
 	req.arp_flags = ATF_PERM | ATF_PUBL;
 
-	safe_strncpy(req.arp_dev, tuntap(tun).devname, sizeof(req.arp_dev));
+	strlcpy(req.arp_dev, tuntap(tun).devname, sizeof(req.arp_dev));
 
 	if (ioctl(sockfd, SIOCDARP, &req) < 0) {
 	  perror("ioctrl()");
@@ -4958,11 +4958,11 @@ int cb_dhcp_request(struct dhcp_conn_t *conn, struct in_addr *addr,
 
 	  safe_snprintf(mac, sizeof(mac), MAC_FMT, MAC_ARG(conn->hismac));
 
-	  safe_strncpy(appconn->s_state.redir.username, mac, USERNAMESIZE);
+	  strlcpy(appconn->s_state.redir.username, mac, USERNAMESIZE);
 
 	  if (_options.macsuffix) {
 	    size_t ulen = strlen(appconn->s_state.redir.username);
-	    safe_strncpy(appconn->s_state.redir.username + ulen,
+	    strlcpy(appconn->s_state.redir.username + ulen,
 			 _options.macsuffix, USERNAMESIZE - ulen);
 	  }
 
@@ -6538,7 +6538,7 @@ int chilli_cmd(struct cmdsock_request *req, bstring s, int sock) {
 	  for (i = 0; i < appconn->s_params.pass_through_count; i++) {
 	    pt = &appconn->s_params.pass_throughs[i];
 
-	    safe_strncpy(mask, inet_ntoa(pt->mask), sizeof(mask));
+	    strlcpy(mask, inet_ntoa(pt->mask), sizeof(mask));
 
 	    bassignformat(tmp,
 			  "%20s: host=%-16s mask=%-16s proto=%-3d port=%-3d"
@@ -6772,7 +6772,7 @@ int chilli_cmd(struct cmdsock_request *req, bstring s, int sock) {
 	for (i=0; !err && i<tun->_interface_count; i++) {
 	  char gw[56];
 
-	  safe_strncpy(gw, inet_ntoa(tun->_interfaces[i].gateway), sizeof(gw));
+	  strlcpy(gw, inet_ntoa(tun->_interfaces[i].gateway), sizeof(gw));
 
 	  bassignformat(b, "idx: %d dev: %s %s "MAC_FMT" "
 			"%s "MAC_FMT"%s\n",
@@ -6828,7 +6828,7 @@ int chilli_cmd(struct cmdsock_request *req, bstring s, int sock) {
 	       sizeof(req->d.sess.params));
 
 	if (uname[0])
-	  safe_strncpy(appconn->s_state.redir.username,
+	  strlcpy(appconn->s_state.redir.username,
 		       uname, USERNAMESIZE);
 
 	session_param_defaults(&appconn->s_params);
@@ -7472,7 +7472,7 @@ int chilli_main(int argc, char **argv) {
 
   if (_options.adminuser) {
     admin_session.is_adminsession = 1;
-    safe_strncpy(admin_session.s_state.redir.username,
+    strlcpy(admin_session.s_state.redir.username,
 		 _options.adminuser,
 		 sizeof(admin_session.s_state.redir.username));
     set_sessionid(&admin_session, 0);

--- a/src/chilli.h
+++ b/src/chilli.h
@@ -36,6 +36,10 @@
 #include "md5.h"
 #include "dns.h"
 
+#ifndef HAVE_STRLCPY
+size_t strlcpy(char *dst, const char *src, size_t dsize);
+#endif
+
 /*#define XXX_IO_DAEMON 1*/
 
 /* Authtype defs */

--- a/src/chilli.h
+++ b/src/chilli.h
@@ -37,7 +37,7 @@
 #include "dns.h"
 
 #ifndef HAVE_STRLCPY
-size_t strlcpy(char *dst, const char *src, size_t dsize);
+extern size_t strlcpy(char *dst, const char *src, size_t dsize);
 #endif
 
 /*#define XXX_IO_DAEMON 1*/

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -3588,7 +3588,7 @@ int dhcp_set_addrs(struct dhcp_conn_t *conn,
 #endif
 
   if (!conn->domain[0] && _options.domain) {
-    safe_strncpy(conn->domain, _options.domain, DHCP_DOMAIN_LEN);
+    strlcpy(conn->domain, _options.domain, DHCP_DOMAIN_LEN);
   }
 
 #if defined(ENABLE_TAP) && defined(SIOCSARP)
@@ -3613,7 +3613,7 @@ int dhcp_set_addrs(struct dhcp_conn_t *conn,
 	      inet_ntoa(conn->hisip),
 	      MAC_ARG(conn->hismac));
 
-      safe_strncpy(req.arp_dev, tuntap(tun).devname, sizeof(req.arp_dev));
+      strlcpy(req.arp_dev, tuntap(tun).devname, sizeof(req.arp_dev));
 
       if (ioctl(sockfd, SIOCSARP, &req) < 0) {
 	perror("ioctrl()");

--- a/src/garden.c
+++ b/src/garden.c
@@ -37,7 +37,7 @@ void garden_print_list(int fd, pass_through *ptlist, int ptcnt) {
   for (i = 0; i < ptcnt; i++) {
     pt = &ptlist[i];
 
-    safe_strncpy(mask, inet_ntoa(pt->mask), sizeof(mask));
+    strlcpy(mask, inet_ntoa(pt->mask), sizeof(mask));
 
     safe_snprintf(line, sizeof(line),
 		  "host=%-16s mask=%-16s proto=%-3d port=%-3d"
@@ -603,15 +603,15 @@ int regex_pass_throughs_from_string(regex_pass_through *ptlist, uint32_t ptlen,
       if (is_negate) p++;
       switch (stage) {
       case 0:
-	safe_strncpy(pt.regex_host, p, sizeof(pt.regex_host));
+	strlcpy(pt.regex_host, p, sizeof(pt.regex_host));
 	pt.neg_host = is_negate;
 	break;
       case 1:
-	safe_strncpy(pt.regex_path, p, sizeof(pt.regex_path));
+	strlcpy(pt.regex_path, p, sizeof(pt.regex_path));
 	pt.neg_path = is_negate;
 	break;
       case 2:
-	safe_strncpy(pt.regex_qs, p, sizeof(pt.regex_qs));
+	strlcpy(pt.regex_qs, p, sizeof(pt.regex_qs));
 	pt.neg_qs   = is_negate;
 	break;
       }

--- a/src/main-opt.c
+++ b/src/main-opt.c
@@ -1229,10 +1229,10 @@ int main(int argc, char **argv) {
 	  _options.extadmvsa[numargs].attr_vsa = i[0];
 	  _options.extadmvsa[numargs].attr = i[1];
 	  if (idx) *idx = 0;
-	  safe_strncpy(_options.extadmvsa[numargs].script,
+	  strlcpy(_options.extadmvsa[numargs].script,
 		       s, sizeof(_options.extadmvsa[numargs].script)-1);
 	  if (idx) {
-	    safe_strncpy(_options.extadmvsa[numargs].data,
+	    strlcpy(_options.extadmvsa[numargs].data,
 			 idx + 1, sizeof(_options.extadmvsa[numargs].data)-1);
 	  }
 	} else if (sscanf(args_info.extadmvsa_arg[numargs],
@@ -1240,10 +1240,10 @@ int main(int argc, char **argv) {
 	  char *idx = strchr(s, ':');
 	  _options.extadmvsa[numargs].attr = i[0];
 	  if (idx) *idx = 0;
-	  safe_strncpy(_options.extadmvsa[numargs].script,
+	  strlcpy(_options.extadmvsa[numargs].script,
 		       s, sizeof(_options.extadmvsa[numargs].script)-1);
 	  if (idx) {
-	    safe_strncpy(_options.extadmvsa[numargs].data,
+	    strlcpy(_options.extadmvsa[numargs].data,
 			 idx + 1, sizeof(_options.extadmvsa[numargs].data)-1);
 	  }
 	} else {

--- a/src/main-proxy.c
+++ b/src/main-proxy.c
@@ -1113,7 +1113,7 @@ int main(int argc, char **argv) {
 
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
 
-    safe_strncpy(ifr.ifr_name, _options.dhcpif, sizeof(ifr.ifr_name));
+    strlcpy(ifr.ifr_name, _options.dhcpif, sizeof(ifr.ifr_name));
 
     if (ioctl(fd, SIOCGIFHWADDR, (caddr_t)&ifr) == 0) {
       memcpy(nas_hwaddr, ifr.ifr_hwaddr.sa_data, PKT_ETH_ALEN);

--- a/src/main-query.c
+++ b/src/main-query.c
@@ -318,7 +318,7 @@ static int process_args(int argc, char *argv[], int argidx) {
 	  parse_mac(((uint8_t *)args[i].field), argv[argidx+1]);
 	  break;
 	case CMDSOCK_FIELD_STRING:
-	  safe_strncpy(((char *)args[i].field), argv[argidx+1], args[i].length);
+	  strlcpy(((char *)args[i].field), argv[argidx+1], args[i].length);
 	  break;
 	case CMDSOCK_FIELD_INTEGER:
 	  switch(args[i].length) {

--- a/src/main-radconfig.c
+++ b/src/main-radconfig.c
@@ -93,7 +93,7 @@ int static chilliauth() {
     int fd;
     if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) >= 0) {
       memset(&ifr, 0, sizeof(ifr));
-      safe_strncpy(ifr.ifr_name, _options.dhcpif, IFNAMSIZ);
+      strlcpy(ifr.ifr_name, _options.dhcpif, IFNAMSIZ);
       if (ioctl(fd, SIOCGIFHWADDR, &ifr) < 0) {
 	syslog(LOG_ERR, "%s: ioctl(d=%d, request=%d) failed", strerror(errno), fd, SIOCGIFHWADDR);
       }

--- a/src/main-redir.c
+++ b/src/main-redir.c
@@ -548,12 +548,12 @@ redir_handle_url(struct redir_t *redir,
 #ifdef ENABLE_REDIRINJECT
   char hasInject = 0;
   if (conn->s_params.flags & UAM_INJECT_URL) {
-    safe_strncpy((char *) req->inject_url,
+    strlcpy((char *) req->inject_url,
 		 (char *) conn->s_params.url,
 		 REDIRINJECT_MAX);
     matches = hasInject = 1;
   } else if (_options.inject && *_options.inject) {
-    safe_strncpy((char *) req->inject_url,
+    strlcpy((char *) req->inject_url,
 		 (char *) _options.inject,
 		 REDIRINJECT_MAX);
     matches = hasInject = 1;
@@ -821,7 +821,7 @@ int main(int argc, char **argv) {
 
   process_options(argc, argv, 1);
 
-  safe_strncpy(ifr.ifr_name, _options.dhcpif, sizeof(ifr.ifr_name));
+  strlcpy(ifr.ifr_name, _options.dhcpif, sizeof(ifr.ifr_name));
 
 #ifdef SIOCGIFHWADDR
   if (ioctl(fd, SIOCGIFHWADDR, (caddr_t)&ifr) == 0) {

--- a/src/main-response.c
+++ b/src/main-response.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
   if (strlen(argv[idx+1]) >= sizeof(buffer))
     return usage(argv[0]);
   memset(buffer, 0, sizeof(buffer));
-  safe_strncpy(buffer, argv[idx+1], sizeof(buffer));
+  strlcpy(buffer, argv[idx+1], sizeof(buffer));
   hextochar(buffer, challenge, MD5LEN);
 
   /* uamsecret - argv 2 */
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
     int m, n, plen = strlen(argv[idx+3]);
 
     memset(p, 0, sizeof(p));
-    safe_strncpy((char *)p, argv[idx+3], RADIUS_PWSIZE);
+    strlcpy((char *)p, argv[idx+3], RADIUS_PWSIZE);
 
     for (m=0; m < plen;) {
       for (n=0; n < REDIR_MD5LEN; m++, n++) {

--- a/src/net.c
+++ b/src/net.c
@@ -45,7 +45,7 @@ int dev_set_flags(char const *dev, int flags) {
 
   memset(&ifr, 0, sizeof(ifr));
   ifr.ifr_flags = flags;
-  safe_strncpy(ifr.ifr_name, dev, IFNAMSIZ);
+  strlcpy(ifr.ifr_name, dev, IFNAMSIZ);
 
   if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
     syslog(LOG_ERR, "%s: socket() failed", strerror(errno));
@@ -68,7 +68,7 @@ int dev_get_flags(char const *dev, int *flags) {
   int fd;
 
   memset(&ifr, 0, sizeof(ifr));
-  safe_strncpy(ifr.ifr_name, dev, IFNAMSIZ);
+  strlcpy(ifr.ifr_name, dev, IFNAMSIZ);
 
   if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
     syslog(LOG_ERR, "%s: socket() failed", strerror(errno));
@@ -106,7 +106,7 @@ int dev_set_address(char const *devname, struct in_addr *address,
   }
 
 #if defined(__linux__)
-  safe_strncpy(ifr.ifr_name, devname, IFNAMSIZ);
+  strlcpy(ifr.ifr_name, devname, IFNAMSIZ);
   ifr.ifr_addr.sa_family = AF_INET;
   ifr.ifr_dstaddr.sa_family = AF_INET;
   ifr.ifr_netmask.sa_family = AF_INET;
@@ -188,7 +188,7 @@ int net_init(net_interface *netif, char *ifname,
 
   if (ifname) {
     memset(netif, 0, sizeof(net_interface));
-    safe_strncpy(netif->devname, ifname, IFNAMSIZ);
+    strlcpy(netif->devname, ifname, IFNAMSIZ);
   }
 
   netif->protocol = protocol;
@@ -964,7 +964,7 @@ int net_set_mtu(net_interface *netif, size_t mtu) {
   int fd = socket(AF_INET, SOCK_DGRAM, 0);
   if (fd < 0) return -1;
   memset(&ifr, 0, sizeof(ifr));
-  safe_strncpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
+  strlcpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
   ifr.ifr_mtu = mtu;
   if (ioctl(fd, SIOCSIFMTU, &ifr) < 0) {
     syslog(LOG_ERR, "%d could not set MTU of %zu on dev=%s",
@@ -1124,7 +1124,7 @@ int net_getip(char *dev, struct in_addr *addr) {
   struct ifreq ifr;
   int ret = -1;
   int fd=socket(AF_INET, SOCK_DGRAM, 0);
-  safe_strncpy(ifr.ifr_name, dev, sizeof(ifr.ifr_name));
+  strlcpy(ifr.ifr_name, dev, sizeof(ifr.ifr_name));
   if (ioctl(fd, SIOCGIFADDR, (caddr_t)&ifr) >= 0) {
     struct sockaddr *sa = (struct sockaddr *)&(ifr.ifr_addr);
     memcpy(addr, &((struct sockaddr_in *)sa)->sin_addr, sizeof(struct in_addr));
@@ -1178,7 +1178,7 @@ int net_open_eth(net_interface *netif) {
   memset(&ifr, 0, sizeof(ifr));
 
   /* Get ifindex */
-  safe_strncpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
+  strlcpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
   if (ioctl(netif->fd, SIOCGIFINDEX, (caddr_t)&ifr) < 0) {
     syslog(LOG_ERR, "%s: ioctl(SIOCFIGINDEX) failed", strerror(errno));
   }
@@ -1186,7 +1186,7 @@ int net_open_eth(net_interface *netif) {
   netif->ifindex = ifr.ifr_ifindex;
 
   /* Get the MAC address of our interface */
-  safe_strncpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
+  strlcpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
   if (ioctl(netif->fd, SIOCGIFHWADDR, (caddr_t)&ifr) < 0) {
     syslog(LOG_ERR, "%s: ioctl(d=%d, request=%d) failed", strerror(errno), netif->fd, SIOCGIFHWADDR);
     return -1;
@@ -1197,7 +1197,7 @@ int net_open_eth(net_interface *netif) {
     if ((netif->flags & NET_USEMAC) == 0) {
       memcpy(netif->hwaddr, ifr.ifr_hwaddr.sa_data, PKT_ETH_ALEN);
     } else if (_options.dhcpmacset) {
-      safe_strncpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
+      strlcpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
       memcpy(ifr.ifr_hwaddr.sa_data, netif->hwaddr, PKT_ETH_ALEN);
       if (ioctl(netif->fd, SIOCSIFHWADDR, (caddr_t)&ifr) < 0) {
 	syslog(LOG_ERR, "%s: ioctl(d=%d, request=%d) failed", strerror(errno), netif->fd, SIOCSIFHWADDR);
@@ -1287,7 +1287,7 @@ int net_open_eth(net_interface *netif) {
 #endif
 
   /* Get the MAC address of our interface */
-  safe_strncpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
+  strlcpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
   if (ioctl(netif->fd, SIOCGIFHWADDR, (caddr_t)&ifr) < 0) {
     syslog(LOG_ERR, "%s: ioctl(d=%d, request=%d) failed", strerror(errno), netif->fd, SIOCGIFHWADDR);
     return -1;
@@ -1298,7 +1298,7 @@ int net_open_eth(net_interface *netif) {
     if ((netif->flags & NET_USEMAC) == 0) {
       memcpy(netif->hwaddr, ifr.ifr_hwaddr.sa_data, PKT_ETH_ALEN);
     } else if (_options.dhcpmacset) {
-      safe_strncpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
+      strlcpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
       memcpy(ifr.ifr_hwaddr.sa_data, netif->hwaddr, PKT_ETH_ALEN);
       if (ioctl(netif->fd, SIOCSIFHWADDR, (caddr_t)&ifr) < 0) {
 	syslog(LOG_ERR, "%s: ioctl(d=%d, request=%d) failed", strerror(errno), netif->fd, SIOCSIFHWADDR);
@@ -1316,7 +1316,7 @@ int net_open_eth(net_interface *netif) {
   /* Get the IP address of our interface */
 
   /* Verify that MTU = ETH_DATA_LEN */
-  safe_strncpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
+  strlcpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
   if (ioctl(netif->fd, SIOCGIFMTU, (caddr_t)&ifr) < 0) {
     syslog(LOG_ERR, "%s: ioctl(d=%d, request=%d) failed", strerror(errno), netif->fd, SIOCGIFMTU);
     return -1;
@@ -1329,7 +1329,7 @@ int net_open_eth(net_interface *netif) {
   netif->mtu = ifr.ifr_mtu;
 
   /* Get ifindex */
-  safe_strncpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
+  strlcpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
   if (ioctl(netif->fd, SIOCGIFINDEX, (caddr_t)&ifr) < 0) {
     syslog(LOG_ERR, "%s: ioctl(SIOCFIGINDEX) failed", strerror(errno));
   }
@@ -1388,7 +1388,7 @@ int net_open_eth(net_interface *netif) {
     struct packet_mreq mr;
 
     memset(&ifr, 0, sizeof(ifr));
-    safe_strncpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
+    strlcpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
     if (ioctl(netif->fd, SIOCGIFFLAGS, (caddr_t)&ifr) == -1) {
       syslog(LOG_ERR, "%s: ioctl(SIOCGIFFLAGS)", strerror(errno));
     } else {
@@ -1540,7 +1540,7 @@ int net_open_eth(net_interface *netif) {
 
   /* Set the interface */
   memset(&ifr, 0, sizeof(ifr));
-  safe_strncpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
+  strlcpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
   if (ioctl(netif->fd, BIOCSETIF, &ifr) < 0) {
     syslog(LOG_ERR, "%s: ioctl() failed", strerror(errno));
     return -1;

--- a/src/radius.c
+++ b/src/radius.c
@@ -1406,7 +1406,7 @@ void radius_set(struct radius_t *this, unsigned char *hwaddr, int debug) {
     this->hisaddr1.s_addr = this->hisaddr0.s_addr;
 
     this->secretlen = 6;
-    safe_strncpy(this->secret, "radsec", sizeof(this->secret));
+    strlcpy(this->secret, "radsec", sizeof(this->secret));
   } else {
     this->hisaddr0.s_addr = _options.radiusserver1.s_addr;
     this->hisaddr1.s_addr = _options.radiusserver2.s_addr;

--- a/src/redir.c
+++ b/src/redir.c
@@ -205,7 +205,7 @@ static int bstrtocstr(bstring src, char *dst, unsigned int len) {
     return 0;
   }
 
-  safe_strncpy(dst, (char*)src->data, len);
+  strlcpy(dst, (char*)src->data, len);
   return 0;
 }
 
@@ -1776,7 +1776,7 @@ int redir_ipc(struct redir_t *redir) {
 
     local.sun_family = AF_UNIX;
 
-    safe_strncpy(local.sun_path, filedest,
+    strlcpy(local.sun_path, filedest,
 		 sizeof(local.sun_path));
     unlink(local.sun_path);
 
@@ -2107,7 +2107,7 @@ static int redir_getreq(struct redir_t *redir, struct redir_socket_t *sock,
 	if (!p2) { syslog(LOG_ERR, "parse error"); return -1; }
 	*p2 = 0;
 
-	safe_strncpy(path, p1, sizeof(httpreq->path));
+	strlcpy(path, p1, sizeof(httpreq->path));
 
 	syslog(LOG_DEBUG, "The path: %s", path);
 
@@ -2160,7 +2160,7 @@ static int redir_getreq(struct redir_t *redir, struct redir_socket_t *sock,
 	  if (p2) {
 	    *p2 = 0;
 
-	    safe_strncpy(httpreq->qs, p1, sizeof(httpreq->qs));
+	    strlcpy(httpreq->qs, p1, sizeof(httpreq->qs));
 
 #if(_debug_ > 1)
 	    syslog(LOG_DEBUG, "Query string: %s", httpreq->qs);
@@ -2183,7 +2183,7 @@ static int redir_getreq(struct redir_t *redir, struct redir_socket_t *sock,
 	if (!strncasecmp(buffer,"Host:",5)) {
 	  p = buffer + 5;
 	  while (*p && isspace((int) *p)) p++;
-	  safe_strncpy(httpreq->host, p, sizeof(httpreq->host));
+	  strlcpy(httpreq->host, p, sizeof(httpreq->host));
 #if(_debug_ > 1)
 	  syslog(LOG_DEBUG, "Host: %s",httpreq->host);
 #endif
@@ -2201,7 +2201,7 @@ static int redir_getreq(struct redir_t *redir, struct redir_socket_t *sock,
 	else if (!strncasecmp(buffer,"User-Agent:",11)) {
 	  p = buffer + 11;
 	  while (*p && isspace((int) *p)) p++;
-	  safe_strncpy(conn->s_state.redir.useragent,
+	  strlcpy(conn->s_state.redir.useragent,
 		       p, sizeof(conn->s_state.redir.useragent));
 #if(_debug_)
 	  syslog(LOG_DEBUG, "User-Agent: %s",conn->s_state.redir.useragent);
@@ -2212,7 +2212,7 @@ static int redir_getreq(struct redir_t *redir, struct redir_socket_t *sock,
 	else if (!strncasecmp(buffer,"Accept-Language:",16)) {
 	  p = buffer + 16;
 	  while (*p && isspace((int) *p)) p++;
-	  safe_strncpy(conn->s_state.redir.acceptlanguage,
+	  strlcpy(conn->s_state.redir.acceptlanguage,
 		       p, sizeof(conn->s_state.redir.acceptlanguage));
 #if(_debug_ > 1)
 	  syslog(LOG_DEBUG, "Accept-Language: %s",conn->s_state.redir.acceptlanguage);
@@ -2222,7 +2222,7 @@ static int redir_getreq(struct redir_t *redir, struct redir_socket_t *sock,
 	else if (!strncasecmp(buffer,"Cookie:",7)) {
 	  p = buffer + 7;
 	  while (*p && isspace((int) *p)) p++;
-	  safe_strncpy(conn->httpcookie, p, sizeof(conn->httpcookie));
+	  strlcpy(conn->httpcookie, p, sizeof(conn->httpcookie));
 #if(_debug_ > 1)
 	  syslog(LOG_DEBUG, "Cookie: %s",conn->httpcookie);
 #endif
@@ -2704,7 +2704,7 @@ static int redir_radius(struct redir_t *redir, struct in_addr *addr,
 
   case REDIR_AUTH_PAP:
     if (_options.nochallenge) {
-      safe_strncpy((char*)user_password,
+      strlcpy((char*)user_password,
                    (char*)conn->authdata.v.papmsg.password,
                    sizeof(user_password));
     } else {
@@ -2932,7 +2932,7 @@ int is_local_user(struct redir_t *redir, struct redir_conn_t *conn) {
   switch (conn->authdata.type){
   case REDIR_AUTH_PAP:
     if (_options.nochallenge) {
-      safe_strncpy((char*)user_password,
+      strlcpy((char*)user_password,
                    (char*)conn->authdata.v.papmsg.password,
                    sizeof(user_password));
     } else {
@@ -3146,7 +3146,7 @@ int redir_send_msg(struct redir_t *this, struct redir_msg_t *msg) {
   }
 
   remote.sun_family = AF_UNIX;
-  safe_strncpy(remote.sun_path, filedest,
+  strlcpy(remote.sun_path, filedest,
 	       sizeof(remote.sun_path));
 
 #if defined (__FreeBSD__)  || defined (__APPLE__) || defined (__OpenBSD__)

--- a/src/rtmon.c
+++ b/src/rtmon.c
@@ -406,7 +406,7 @@ void rtmon_check_updates(struct rtmon_t *rtmon) {
 	      sin->sin_family = AF_INET;
 	      sin->sin_addr.s_addr = rtmon->_routes[i].gateway.s_addr;
 
-	      safe_strncpy(areq.arp_dev, rtmon->_ifaces[j].devname, sizeof(areq.arp_dev));
+	      strlcpy(areq.arp_dev, rtmon->_ifaces[j].devname, sizeof(areq.arp_dev));
 
 	      while (attempt < retries) {
 		struct sockaddr_in addr;
@@ -531,7 +531,7 @@ void rtmon_discover_ifaces(struct rtmon_t *rtmon) {
     memset(&ri, 0, sizeof(ri));
 
     /* device name and address */
-    safe_strncpy(ri.devname, ifr->ifr_name, sizeof(ri.devname));
+    strlcpy(ri.devname, ifr->ifr_name, sizeof(ri.devname));
     ri.address = inaddr(ifr_addr);
 
     /* index */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -241,7 +241,7 @@ _openssl_env_init(openssl_env *env, char *engine, int server) {
 
 #ifdef HAVE_OPENSSL
 static int _openssl_passwd(char *buf, int size, int rwflag, void *ud) {
-  safe_strncpy(buf, _options.sslkeypass, size);
+  strlcpy(buf, _options.sslkeypass, size);
   memset(_options.sslkeypass,'x',strlen(_options.sslkeypass));
   return 0;
 }

--- a/src/system.h
+++ b/src/system.h
@@ -263,7 +263,6 @@
 #include <errno.h>
 
 #define safe_snprintf portable_snprintf
-char *safe_strncpy(char *dst, const char *src, size_t size);
 
 int safe_accept(int fd, struct sockaddr *sa, socklen_t *lenptr);
 int safe_select(int nfds, fd_set *readfds, fd_set *writefds,

--- a/src/tun.c
+++ b/src/tun.c
@@ -106,7 +106,7 @@ int tun_name2idx(struct tun_t *tun, char *name) {
       net_interface netif;
       syslog(LOG_DEBUG, "Discoving TUN %s", name);
       memset(&netif, 0, sizeof(netif));
-      safe_strncpy(netif.devname, rti->devname, sizeof(netif.devname));
+      strlcpy(netif.devname, rti->devname, sizeof(netif.devname));
       memcpy(netif.hwaddr, rti->hwaddr, sizeof(netif.hwaddr));
       netif.address = rti->address;
       netif.netmask = rti->netmask;
@@ -177,7 +177,7 @@ int tun_discover(struct tun_t *this) {
     memset(&netif, 0, sizeof(netif));
 
     /* device name and address */
-    safe_strncpy(netif.devname, ifr->ifr_name, sizeof(netif.devname));
+    strlcpy(netif.devname, ifr->ifr_name, sizeof(netif.devname));
     netif.address = inaddr(ifr_addr);
 
     syslog(LOG_DEBUG, "Interface: %s", ifr->ifr_name);
@@ -331,7 +331,7 @@ int tun_gifindex(struct tun_t *this, uint32_t *index) {
   ifr.ifr_addr.sa_family = AF_INET;
   ifr.ifr_dstaddr.sa_family = AF_INET;
   ifr.ifr_netmask.sa_family = AF_INET;
-  safe_strncpy(ifr.ifr_name, tuntap(this).devname, IFNAMSIZ);
+  strlcpy(ifr.ifr_name, tuntap(this).devname, IFNAMSIZ);
   if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
     syslog(LOG_ERR, "%s: socket() failed", strerror(errno));
   }
@@ -463,7 +463,7 @@ int tun_addaddr(struct tun_t *this, struct in_addr *addr,
   memset(&areq, 0, sizeof(areq));
 
   /* Set up interface name */
-  safe_strncpy(areq.ifra_name, tuntap(this).devname, IFNAMSIZ);
+  strlcpy(areq.ifra_name, tuntap(this).devname, IFNAMSIZ);
 
   ((struct sockaddr_in*) &areq.ifra_addr)->sin_family = AF_INET;
   ((struct sockaddr_in*) &areq.ifra_addr)->sin_len = sizeof(areq.ifra_addr);
@@ -581,7 +581,7 @@ int tuntap_interface(struct _net_interface *netif) {
 
   if (_options.tundev && *_options.tundev &&
       strcmp(_options.tundev, "tap") && strcmp(_options.tundev, "tun"))
-    safe_strncpy(ifr.ifr_name, _options.tundev, IFNAMSIZ);
+    strlcpy(ifr.ifr_name, _options.tundev, IFNAMSIZ);
 
   if (ioctl(netif->fd, TUNSETIFF, (void *) &ifr) < 0) {
     syslog(LOG_ERR, "%s: ioctl() failed", strerror(errno));
@@ -595,7 +595,7 @@ int tuntap_interface(struct _net_interface *netif) {
     int nfd;
     memset(&nifr, 0, sizeof(nifr));
     if ((nfd = socket (AF_INET, SOCK_DGRAM, 0)) >= 0) {
-      safe_strncpy(nifr.ifr_name, ifr.ifr_name, IFNAMSIZ);
+      strlcpy(nifr.ifr_name, ifr.ifr_name, IFNAMSIZ);
       nifr.ifr_qlen = _options.txqlen;
 
       if (ioctl(nfd, SIOCSIFTXQLEN, (void *) &nifr) >= 0)
@@ -610,7 +610,7 @@ int tuntap_interface(struct _net_interface *netif) {
   }
 #endif
 
-  safe_strncpy(netif->devname, ifr.ifr_name, IFNAMSIZ);
+  strlcpy(netif->devname, ifr.ifr_name, IFNAMSIZ);
 
   ioctl(netif->fd, TUNSETNOCSUM, 1); /* Disable checksums */
 
@@ -621,7 +621,7 @@ int tuntap_interface(struct _net_interface *netif) {
     netif->flags |= NET_ETHHDR;
     if ((fd = socket (AF_INET, SOCK_DGRAM, 0)) >= 0) {
       memset(&ifr, 0, sizeof(ifr));
-      safe_strncpy(ifr.ifr_name, netif->devname, IFNAMSIZ);
+      strlcpy(ifr.ifr_name, netif->devname, IFNAMSIZ);
       if (ioctl(fd, SIOCGIFHWADDR, &ifr) < 0) {
 	syslog(LOG_ERR, "%s: ioctl(d=%d, request=%d) failed", strerror(errno), fd, SIOCGIFHWADDR);
       }
@@ -660,7 +660,7 @@ int tuntap_interface(struct _net_interface *netif) {
   memset(&areq, 0, sizeof(areq));
 
   /* Set up interface name */
-  safe_strncpy(areq.ifra_name, netif->devname, sizeof(areq.ifra_name));
+  strlcpy(areq.ifra_name, netif->devname, sizeof(areq.ifra_name));
 
   /* Create a channel to the NET kernel. */
   if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
@@ -720,7 +720,7 @@ int tuntap_interface(struct _net_interface *netif) {
 		"tun%d", ppa);
 
   memset(&ifr, 0, sizeof(ifr));
-  safe_strncpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
+  strlcpy(ifr.ifr_name, netif->devname, sizeof(ifr.ifr_name));
   ifr.ifr_ip_muxid = muxid;
 
   if (ioctl(ip_fd, SIOCSIFMUXID, &ifr) < 0) {

--- a/src/util.c
+++ b/src/util.c
@@ -20,12 +20,6 @@
 
 #include "chilli.h"
 
-char *safe_strncpy(char *dst, const char *src, size_t size) {
-  if (!size) return dst;
-  dst[--size] = '\0';
-  return strncpy(dst, src, size);
-}
-
 int statedir_file(char *dst, int dlen, char *file, char *deffile) {
   char *statedir = _options.statedir ? _options.statedir : DEFSTATEDIR;
   if (!file && deffile) {

--- a/src/util.c
+++ b/src/util.c
@@ -113,7 +113,7 @@ int get_urlparts(char *src, char *host, int hostsize, int *port, int *uripos) {
     return -1;
   }
 
-  safe_strncpy(host, slashslash, hostsize);
+  strlcpy(host, slashslash, hostsize);
   host[hostlen] = 0;
 
   if (uripos) {


### PR DESCRIPTION
Use a tried and tested function commonly found on modern operating systems. Include the implementation to use on systems which do not ship with it as standard.

Signed-by: Sevan Janiyan <venture37@geeklan.co.uk>