### PR TITLE
Bugs and memory leaks fixed

### DIFF
--- a/bstring/bstraux.c
+++ b/bstring/bstraux.c
@@ -193,10 +193,6 @@ int i, l, c;
 }
 
 static size_t readNothing (void *buff, size_t elsize, size_t nelem, void *parm) {
-	buff = buff;
-	elsize = elsize;
-	nelem = nelem;
-	parm = parm;
 	return 0; /* Immediately indicate EOF. */
 }
 
@@ -844,8 +840,6 @@ int obl;
 bstring bStrfTime (const char * fmt, const struct tm * timeptr) {
 #if defined (__TURBOC__) && !defined (__BORLANDC__)
 static struct tagbstring ns = bsStatic ("bStrfTime Not supported");
-	fmt = fmt;
-	timeptr = timeptr;
 	return &ns;
 #else
 bstring buff;

--- a/bstring/snprintf.c
+++ b/bstring/snprintf.c
@@ -574,8 +574,8 @@ int portable_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap) {
       char length_modifier = '\0';            /* allowed values: \0, h, l, L */
       char tmp[32];/* temporary buffer for simple numeric->string conversion */
 
-      const char *str_arg;      /* string address in case of string argument */
-      size_t str_arg_l;         /* natural field width of arg without padding
+      const char *str_arg = NULL;/* string address in case of string argument */
+      size_t str_arg_l;          /* natural field width of arg without padding
                                    and sign */
       unsigned char uchar_arg;
         /* unsigned char argument value - only defined for c conversion.
@@ -592,8 +592,6 @@ int portable_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap) {
       char fmt_spec = '\0';
         /* current conversion specifier character */
 
-      str_arg = credits;/* just to make compiler happy (defined but not used)*/
-      str_arg = NULL;
       starting_p = p; p++;  /* skip '%' */
    /* parse flags */
       while (*p == '0' || *p == '-' || *p == '+' ||

--- a/json/debug.c
+++ b/json/debug.c
@@ -42,19 +42,27 @@ void mc_abort(const char *msg, ...)
 {
   va_list ap;
   va_start(ap, msg);
-  if(_syslog) vsyslog(LOG_ERR, msg, ap);
-  else vprintf(msg, ap);
+  if(_syslog) {
+    vsyslog(LOG_ERR, msg, ap);
+  } else {
+    vprintf(msg, ap);
+  }
+  va_end(ap);
   exit(1);
 }
 
 
 void mc_debug(const char *msg, ...)
 {
-  va_list ap;
   if(_debug) {
+    va_list ap;
     va_start(ap, msg);
-    if(_syslog) vsyslog(LOG_DEBUG, msg, ap);
-    else vprintf(msg, ap);
+    if(_syslog) {
+      vsyslog(LOG_DEBUG, msg, ap);
+    } else {
+      vprintf(msg, ap);
+    }
+    va_end(ap);
   }
 }
 
@@ -62,14 +70,22 @@ void mc_error(const char *msg, ...)
 {
   va_list ap;
   va_start(ap, msg);
-  if(_syslog) vsyslog(LOG_ERR, msg, ap);
-  else vfprintf(stderr, msg, ap);
+  if(_syslog) {
+    vsyslog(LOG_ERR, msg, ap);
+  } else {
+    vfprintf(stderr, msg, ap);
+  }
+  va_end(ap);
 }
 
 void mc_info(const char *msg, ...)
 {
   va_list ap;
   va_start(ap, msg);
-  if(_syslog) vsyslog(LOG_INFO, msg, ap);
-  else vfprintf(stderr, msg, ap);
+  if(_syslog) {
+    vsyslog(LOG_INFO, msg, ap);
+  } else {
+    vfprintf(stderr, msg, ap);
+  }
+  va_end(ap);
 }

--- a/json/linkhash.c
+++ b/json/linkhash.c
@@ -29,6 +29,7 @@ void lh_abort(const char *msg, ...)
 	va_list ap;
 	va_start(ap, msg);
 	vprintf(msg, ap);
+	va_end(ap);
 	exit(1);
 }
 

--- a/json/printbuf.c
+++ b/json/printbuf.c
@@ -80,8 +80,9 @@ int sprintbuf(struct printbuf *p, const char *msg, ...)
   if(size == -1 || size > 127) {
     int ret;
     va_start(ap, msg);
-    if((size = vasprintf(&t, msg, ap)) == -1) return -1;
+	size = vasprintf(&t, msg, ap);
     va_end(ap);
+    if(size == -1) return -1;
     ret = printbuf_memappend(p, t, size);
     free(t);
     return ret;

--- a/src/chilli.c
+++ b/src/chilli.c
@@ -2439,20 +2439,16 @@ static int fwd_layer3(struct app_conn_t *appconn,
       } else
 #endif
 	{
-	static uint8_t bmac[PKT_ETH_ALEN] =
-	  {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
-
 	struct pkt_ethhdr_t *ethh;
 	uint8_t packet[PKT_MAX_LEN];
 	size_t length = pkt_buffer_length(pb);
 	size_t hdrlen = PKT_ETH_HLEN;
-	uint8_t *dstmac = bmac;
 
 	memset(packet, 0, hdrlen);
 
 	ethh = pkt_ethhdr(packet);
 
-	dstmac = pdhcp->chaddr;
+	uint8_t *dstmac = pdhcp->chaddr;
 
 	memcpy(packet + hdrlen,
 	       pkt_buffer_head(pb),
@@ -7158,11 +7154,25 @@ int chilli_main(int argc, char **argv) {
   /* foreground                                                   */
   /* If flag not given run as a daemon                            */
   if (!_options.foreground) {
-    /* Close the standard file descriptors. */
-    /* Is this really needed ? */
-    if (!freopen("/dev/null", "w", stdout)) syslog(LOG_ERR, "freopen()");
-    if (!freopen("/dev/null", "w", stderr)) syslog(LOG_ERR, "freopen()");
-    if (!freopen("/dev/null", "r", stdin))  syslog(LOG_ERR, "freopen()");
+    FILE *fp = NULL;
+    if (!(fp = freopen("/dev/null", "w", stdout))) {
+		syslog(LOG_ERR, "freopen()");
+	} else {
+		fclose(fp);
+    fp = NULL;
+	}
+    if (!(fp = freopen("/dev/null", "w", stderr))) {
+		syslog(LOG_ERR, "freopen()");
+	} else {
+		fclose(fp);
+    fp = NULL;
+	}
+    if (!(fp = freopen("/dev/null", "r", stdin))) {
+		syslog(LOG_ERR, "freopen()");
+	} else {
+		fclose(fp);
+    fp = NULL;
+	}
 #if defined (__FreeBSD__)  || defined (__APPLE__) || defined (__OpenBSD__)
     if (fork() > 0) {
       exit(0);

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -3250,8 +3250,6 @@ int dhcp_sendOFFER(struct dhcp_conn_t *conn, uint8_t *pack, size_t len) {
   struct pkt_udphdr_t *packet_udph;
   struct dhcp_packet_t *packet_dhcp;
 
-  uint16_t length = 576 + 4; /* Maximum length */
-  uint16_t udp_len = 576 - 20; /* Maximum length */
   size_t pos = 0;
 
   /* Get packet default values */
@@ -3267,12 +3265,12 @@ int dhcp_sendOFFER(struct dhcp_conn_t *conn, uint8_t *pack, size_t len) {
   pos = dhcp_handler(CHILLI_DHCP_OFFER,
 		     conn, pack, len, packet, pos);
 
-  udp_len = pos + DHCP_MIN_LEN + PKT_UDP_HLEN;
+  uint16_t udp_len = pos + DHCP_MIN_LEN + PKT_UDP_HLEN;
   packet_udph->len = htons(udp_len);
   packet_iph->tot_len = htons(udp_len + PKT_IP_HLEN);
   chksum(packet_iph);
 
-  length = udp_len + sizeofip(packet);
+  uint16_t length = udp_len + sizeofip(packet);
 
   OTHER_SENDING(conn, packet_iph);
   return dhcp_send(this, dhcp_conn_idx(conn), conn->hismac, packet, length);
@@ -3292,8 +3290,6 @@ int dhcp_sendACK(struct dhcp_conn_t *conn, uint8_t *pack, size_t len) {
   struct pkt_udphdr_t *packet_udph;
   struct dhcp_packet_t *packet_dhcp;
 
-  uint16_t length = 576 + 4; /* Maximum length */
-  uint16_t udp_len = 576 - 20; /* Maximum length */
   size_t pos = 0;
 
   /* Get packet default values */
@@ -3309,12 +3305,12 @@ int dhcp_sendACK(struct dhcp_conn_t *conn, uint8_t *pack, size_t len) {
   pos = dhcp_handler(CHILLI_DHCP_ACK,
 		     conn, pack, len, packet, pos);
 
-  udp_len = pos + DHCP_MIN_LEN + PKT_UDP_HLEN;
+  uint16_t udp_len = pos + DHCP_MIN_LEN + PKT_UDP_HLEN;
   packet_udph->len = htons(udp_len);
   packet_iph->tot_len = htons(udp_len + PKT_IP_HLEN);
   chksum(packet_iph);
 
-  length = udp_len + sizeofip(packet);
+  uint16_t length = udp_len + sizeofip(packet);
 
   OTHER_SENDING(conn, packet_iph);
   return dhcp_send(this, dhcp_conn_idx(conn), conn->hismac, packet, length);
@@ -3335,8 +3331,6 @@ int dhcp_sendNAK(struct dhcp_conn_t *conn, uint8_t *pack, size_t len) {
   struct pkt_udphdr_t *packet_udph;
   struct dhcp_packet_t *packet_dhcp;
 
-  uint16_t length = 576 + 4; /* Maximum length */
-  uint16_t udp_len = 576 - 20; /* Maximum length */
   size_t pos = 0;
 
   /* Get packet default values */
@@ -3357,12 +3351,12 @@ int dhcp_sendNAK(struct dhcp_conn_t *conn, uint8_t *pack, size_t len) {
   pos = dhcp_handler(CHILLI_DHCP_NAK,
 		     conn, pack, len, packet, pos);
 
-  udp_len = pos + DHCP_MIN_LEN + PKT_UDP_HLEN;
+  uint16_t udp_len = pos + DHCP_MIN_LEN + PKT_UDP_HLEN;
   packet_udph->len = htons(udp_len);
   packet_iph->tot_len = htons(udp_len + PKT_IP_HLEN);
 
   chksum(packet_iph);
-  length = udp_len + sizeofip(packet);
+  uint16_t length = udp_len + sizeofip(packet);
 
   OTHER_SENDING(conn, packet_iph);
   return dhcp_send(this, dhcp_conn_idx(conn), conn->hismac, packet, length);

--- a/src/queue.c
+++ b/src/queue.c
@@ -19,7 +19,7 @@ static u_int32_t print_pkt (struct nfq_data *tb) {
   ph = nfq_get_msg_packet_hdr(tb);
   if (ph){
     id = ntohl(ph->packet_id);
-    printf("hw_protocol=0x%04x hook=%u id=%u ",
+    printf("hw_protocol=0x%04x hook=%u id=%i ",
 	   ntohs(ph->hw_protocol), ph->hook, id);
   }
 

--- a/src/redir.c
+++ b/src/redir.c
@@ -2953,6 +2953,7 @@ int is_local_user(struct redir_t *redir, struct redir_conn_t *conn) {
   default:
     syslog(LOG_ERR, "Authentication method not supported for locally authenticated users: %d",
 	    conn->authdata.type);
+	fclose(f);
     return 0;
   }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -461,6 +461,7 @@ openssl_accept_fd(openssl_env *env, int fd, int timeout, struct redir_conn_t *co
 
   if (!env || !env->ready) {
     syslog(LOG_ERR, "SSL not available!");
+	openssl_free(c);
     return 0;
   }
 


### PR DESCRIPTION
This PR fixes the following issues:
* Dead code removed (file `bstring/bstraux.c`).
* `va_end` method not called after `va_start` call.
* File descriptor not closed (files `src/redir.c` and `src/chilli.c`).
* `openssl_free` not called (file `src/ssl.c`).
* Incorrect data type in (file `src/queue.c`).

The project is correctly built after these changes (with almost all options enabled).
free free to report me any comment. I will update and squash this PR if needed.