### PR TITLE
add support for extra udp ports in the iptables rules

### DIFF
--- a/conf/defaults.in
+++ b/conf/defaults.in
@@ -149,6 +149,7 @@ HS_UAMHOMEPAGE=http://\$HS_UAMLISTEN:\$HS_UAMPORT/www/coova.html
 # is to block all unwanted traffic to the tun/tap. 
 #
 # HS_TCP_PORTS="80 443"
+# HS_UDP_PORTS="1701"
 
 ###
 #   Standard configurations

--- a/conf/up.sh.in
+++ b/conf/up.sh.in
@@ -43,7 +43,13 @@ run_up() {
 			ipt_in -p tcp -m tcp --dport $port --dst $ADDR -j ACCEPT
 		    done
 		}
-		
+
+		[ -n "$HS_UDP_PORTS" ] && {
+		    for port in $HS_UDP_PORTS; do
+			ipt_in -p udp -m udp --dport $port --dst $ADDR -j ACCEPT
+		    done
+		}
+
 		ipt_in -p udp -d 255.255.255.255 --destination-port 67:68 -j ACCEPT
 		ipt_in -p udp -d $ADDR --destination-port 67:68 -j ACCEPT
 		ipt_in -p udp --dst $ADDR --dport 53 -j ACCEPT

--- a/configure.ac
+++ b/configure.ac
@@ -171,8 +171,8 @@ if test x"$enable_radproxy" = xyes; then
    AC_DEFINE(ENABLE_RADPROXY,1,[Define to enable Chilli RADIUS (EAP) Proxy support])
 fi
 
-AC_ARG_ENABLE(json, [AC_HELP_STRING([--disable-json],[Disable support for JSON])], 
-  enable_json=$enableval, enable_json=yes)
+AC_ARG_ENABLE(json, [AC_HELP_STRING([--enable-json],[Enable support for JSON])], 
+  enable_json=$enableval, enable_json=no)
 
 if test x"$enable_json" = xyes; then
    AC_DEFINE(ENABLE_JSON,1,[Define to enable Chilli JSON])

--- a/configure.ac
+++ b/configure.ac
@@ -172,7 +172,7 @@ if test x"$enable_radproxy" = xyes; then
 fi
 
 AC_ARG_ENABLE(json, [AC_HELP_STRING([--disable-json],[Disable support for JSON])], 
-  enable_json=$enableval, enable_json=no)
+  enable_json=$enableval, enable_json=yes)
 
 if test x"$enable_json" = xyes; then
    AC_DEFINE(ENABLE_JSON,1,[Define to enable Chilli JSON])

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -5431,14 +5431,16 @@ int dhcp_relay_decaps(struct dhcp_t *this, int idx) {
 
   {
     struct pkt_iphdr_t *fullpack_iph = pkt_iphdr(fullpack);
-    struct pkt_udphdr_t *fullpack_udph = pkt_udphdr(fullpack);
+    struct pkt_udphdr_t *fullpack_udph = NULL;
 
     fullpack_iph->version_ihl = PKT_IP_VER_HLEN;
     fullpack_iph->tot_len = htons(length + PKT_UDP_HLEN + PKT_IP_HLEN);
     fullpack_iph->ttl = 0x10;
     fullpack_iph->protocol = 0x11;
-
     fullpack_iph->saddr = _options.dhcplisten.s_addr;
+
+    /* init udph here because pkt_udphdr needs the ip version to get the correct offset */
+    fullpack_udph = pkt_udphdr(fullpack);
     fullpack_udph->src = htons(DHCP_BOOTPS);
     fullpack_udph->len = htons(length + PKT_UDP_HLEN);
 


### PR DESCRIPTION
added a config variable called HS_UDP_PORTS with similar functionality as HS_TCP_PORTS.
I thought it may be useful for protocols like l2tp that need to create a tunnel to the device.