### PR TITLE
Unused variable when _debug_ is not active

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -146,7 +146,9 @@ dns_copy_res(struct dhcp_conn_t *conn, int q,
   char required = 0;
 
   uint16_t type;
+  #if(_debug_)
   uint16_t class;
+  #endif
   uint32_t ttl;
   uint16_t rdlen;
 
@@ -185,7 +187,9 @@ dns_copy_res(struct dhcp_conn_t *conn, int q,
   len -= 2;
 
   memcpy(&us, p_pkt, sizeof(us));
+  #if(_debug_)
   class = ntohs(us);
+  #endif
   p_pkt += 2;
   len -= 2;
 


### PR DESCRIPTION
Var not used if the _debug_ is not defined. 
Fix for issue #101