### PR TITLE
fix order of iptables rules

### DIFF
--- a/conf/up.sh.in
+++ b/conf/up.sh.in
@@ -32,6 +32,8 @@ run_up() {
 	else
 	    if [ "$LAYER3" != "1" ]
 	    then
+		ipt_in --dst $ADDR -j DROP
+		
 		[ -n "$UAMPORT" -a "$UAMPORT" != "0" ] && \
 		    ipt_in -p tcp -m tcp --dport $UAMPORT --dst $ADDR -j ACCEPT
 		
@@ -54,8 +56,6 @@ run_up() {
 		ipt_in -p udp -d $ADDR --destination-port 67:68 -j ACCEPT
 		ipt_in -p udp --dst $ADDR --dport 53 -j ACCEPT
 		ipt_in -p icmp --dst $ADDR -j ACCEPT
-		
-		ipt -A INPUT -i $TUNTAP --dst $ADDR -j DROP
 		
 		if [ "$ONLY8021Q" != "1" ]
 		then


### PR DESCRIPTION
I moved the drop rule to use insert instead of append because it fails to do the job if the system previously has other rules in the INPUT table that are not related to the coova interface. For example in my case the append rule lands after:
-A INPUT -p tcp -m state --state NEW -m tcp --dport 22 -j ACCEPT 
and this allows the hotspot client access to my ssh port, even though the port is not in HS_TCP_PORTS.