### PR TITLE
Add support for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: c
-env: AUTOTOOLS=yes
+before_install: ./bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: c
-before_install: ./bootstrap
+before_install: 
+ - sudo apt-get install gengetopt
+ - ./bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: c
 before_install: 
  - sudo apt-get install gengetopt
  - ./bootstrap
+script:
+ - ./configure
+ - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ before_install:
 script:
  - ./configure
  - make
+compiler:
+ - clang
+ - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 before_install: 
- - sudo apt-get install gengetopt
+ - sudo apt-get update -qq
+ - sudo apt-get install -y gengetopt
  - ./bootstrap
 script:
  - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: c
+env: AUTOTOOLS=yes


### PR DESCRIPTION
A .travis.yml is needed for the @travis-ci build service to build a project.
This yaml file is set to test coova with GCC & clang on Linux.
TODO: Add support to test on OS X too.
With the inclusion of this file to the repo, a person with admin access, @wlanmac? needs to sign into travis-ci.org & activate the service for this repo.