### PR TITLE
Remove the implementation of fork() which was missed through the rename.

### DIFF
--- a/src/safe.c
+++ b/src/safe.c
@@ -150,11 +150,3 @@ int safe_close (int fd) {
   } while (ret == -1 && errno == EINTR);
   return ret;
 }
-
-pid_t fork() {
-  pid_t pid;
-  do {
-    pid = fork();
-  } while (pid == -1 && errno == EINTR);
-  return pid;
-}


### PR DESCRIPTION
	modified:   src/safe.c