### PR TITLE
Remove hacks

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -25,12 +25,6 @@
 #include ENABLE_CONFIG
 #endif
 
-/*
- *   I do not like this here, but otherwise
- *   __u64 is not defined. Set by -ansi
- #undef __STRICT_ANSI__
-*/
-
 #include <ctype.h>
 #include <stdint.h>
 #include <stdarg.h>
@@ -116,6 +110,11 @@
 
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
+#endif
+
+#ifdef HAVE_INTTYPES_H
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #endif
 
 #if defined(__linux__)
@@ -238,33 +237,12 @@
 #include <ifaddrs.h>
 #endif
 
-#undef LITTLE_ENDIAN
-#undef BIG_ENDIAN
-
-#if (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && __BYTE_ORDER == __LITTLE_ENDIAN) || \
-  (defined(i386) || defined(__i386__) || defined(__i486__) ||           \
-   defined(__i586__) || defined(__i686__) || defined(vax) || defined(MIPSEL))
-# define LITTLE_ENDIAN 1
-# define BIG_ENDIAN 0
-#elif (defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && __BYTE_ORDER == __BIG_ENDIAN) || \
-  (defined(sparc) || defined(POWERPC) || defined(mc68000) || defined(sel))
-# define LITTLE_ENDIAN 0
-# define BIG_ENDIAN 1
-#else
-# define LITTLE_ENDIAN 0
-# define BIG_ENDIAN 0
-#endif
-
 #ifndef SI_LOAD_SHIFT
 #define SI_LOAD_SHIFT 16
 #endif
 
 #include <unistd.h>
 #include <errno.h>
-
-#ifndef PRIu64
-#define PRIu64 "lu"
-#endif
 
 int safe_accept(int fd, struct sockaddr *sa, socklen_t *lenptr);
 int safe_select(int nfds, fd_set *readfds, fd_set *writefds,


### PR DESCRIPTION
Host would have a better idea what endian it is.
inttypes.h is needed for PRIu64
Don't undefine __STRICT_ANSI__
Tested on OpenBSD, OS X El Capitan, Alpine Linux (musl libc) on armv7l
	modified:   src/system.h