### PR TITLE
Unbreak configure on Debian 8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,7 @@ AC_CHECK_HEADERS([resolv.h net/route.h net/if.h net/if_arp.h net/if_tun.h net/et
 ])
 
 # Checks for typedefs, structures, and compiler characteristics.
+AC_C_CONST
 AC_CHECK_HEADER_STDBOOL
 AC_TYPE_UID_T
 AC_C_INLINE


### PR DESCRIPTION
AC_C_CONST is needed at present
	modified:   configure.ac