### PR TITLE
fix compilation error in ubuntu

### DIFF
--- a/src/rtmon.c
+++ b/src/rtmon.c
@@ -58,7 +58,7 @@ static int open_netlink() {
   addr.nl_groups = MYMGRP;
 
   if (bind(sock,(struct sockaddr *)&addr,sizeof(addr)) < 0) {
-    syslog(LOG_ERR, "Binding on socket(%p) failed.", sock);
+    syslog(LOG_ERR, "Binding on socket(%d) failed.", sock);
     close(sock);
     return -1;
   }


### PR DESCRIPTION
in Ubuntu this code failed to compile
```
rtmon.c:61:21: error: format '%p' expects argument of type 'void *', but argument 3 has type 'int' [-Werror=format=]
syslog(LOG_ERR, "Binding on socket(%p) failed.", sock);
```