### PR TITLE
fix size_t prints in debug messages for 64bit platforms

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -416,7 +416,7 @@ int dhcp_net_send(struct _net_interface *netif, unsigned char *hismac,
 
 #if(_debug_ > 1)
   if (_options.debug)
-    syslog(LOG_DEBUG, "dhcp_send() len=%d", length);
+    syslog(LOG_DEBUG, "dhcp_send() len=%zd", length);
 #endif
 
   return net_write_eth(netif, packet, length, &netif->dest);
@@ -1735,7 +1735,7 @@ int dhcp_dns(struct dhcp_conn_t *conn, uint8_t *pack,
 #if(_debug_ > 1)
     uint16_t id = ntohs(dnsp->id);
     if (_options.debug) {
-      syslog(LOG_DEBUG, "dhcp_dns plen=%d dlen=%d olen=%d", *plen, dlen, olen);
+      syslog(LOG_DEBUG, "dhcp_dns plen=%zd dlen=%zd olen=%zd", *plen, dlen, olen);
       syslog(LOG_DEBUG, "DNS ID:    %d", id);
       syslog(LOG_DEBUG, "DNS Flags: %d", flags);
     }
@@ -1823,7 +1823,7 @@ int dhcp_dns(struct dhcp_conn_t *conn, uint8_t *pack,
 
 #if(_debug_ > 1)
     if (_options.debug)
-      syslog(LOG_DEBUG, "left (should be zero): %d q=%s", dlen, q);
+      syslog(LOG_DEBUG, "left (should be zero): %zd q=%s", dlen, q);
 #endif
 
     if (dlen) {
@@ -5271,7 +5271,7 @@ int dhcp_decaps_cb(void *pctx, struct pkt_buffer *pb) {
   if (_options.debug) {
     struct pkt_ethhdr_t *ethh = pkt_ethhdr(packet);
     syslog(LOG_DEBUG, "dhcp_decaps: src="MAC_FMT" "
-           "dst="MAC_FMT" prot=%.4x %d len=%d",
+           "dst="MAC_FMT" prot=%.4x %d len=%zd",
            MAC_ARG(ethh->src),
            MAC_ARG(ethh->dst),
            prot, (int)prot, length);
@@ -5642,7 +5642,7 @@ int dhcp_data_req(struct dhcp_conn_t *conn,
     packet = pkt_buffer_head(pb);
     length = pkt_buffer_length(pb);
 #if(_debug_ > 1)
-    syslog(LOG_DEBUG, "adding %d to IP frame length %d", hdrlen, length);
+    syslog(LOG_DEBUG, "adding %zd to IP frame length %zd", hdrlen, length);
 #endif
   }
 
@@ -5748,7 +5748,7 @@ int dhcp_data_req(struct dhcp_conn_t *conn,
     pb->length = length;
 
 #if(_debug_ > 1)
-    syslog(LOG_DEBUG, "adding 20 to frame length %d", length);
+    syslog(LOG_DEBUG, "adding 20 to frame length %zd", length);
 #endif
 
     pkt_buffer_grow(pb, 20);

--- a/src/dns.c
+++ b/src/dns.c
@@ -36,7 +36,7 @@ dns_fullname(char *data, size_t dlen,      /* buffer to store name */
 
 #if(_debug_ > 1)
   if (_options.debug)
-    syslog(LOG_DEBUG, "%s dlen=%d reslen=%d olen=%d lvl=%d",
+    syslog(LOG_DEBUG, "%s dlen=%zd reslen=%zd olen=%zd lvl=%d",
            __FUNCTION__, dlen, reslen, olen, lvl);
 #endif
 
@@ -60,7 +60,7 @@ dns_fullname(char *data, size_t dlen,      /* buffer to store name */
 
 #if(_debug_ > 1)
         if (_options.debug)
-          syslog(LOG_DEBUG, "skip[%d] olen=%d", offset, olen);
+          syslog(LOG_DEBUG, "skip[%d] olen=%zd", offset, olen);
 #endif
 
 	if (dns_fullname(d, dlen,
@@ -80,7 +80,7 @@ dns_fullname(char *data, size_t dlen,      /* buffer to store name */
 
 #if(_debug_ > 1)
     if (_options.debug)
-      syslog(LOG_DEBUG, "part[%.*s] reslen=%d l=%d dlen=%d",
+      syslog(LOG_DEBUG, "part[%.*s] reslen=%zd l=%d dlen=%zd",
              l, res, reslen, l, dlen);
 #endif
 
@@ -162,7 +162,7 @@ dns_copy_res(struct dhcp_conn_t *conn, int q,
 
 #if(_debug_ > 1)
   if (_options.debug)
-    syslog(LOG_DEBUG, "%s: left=%d olen=%d qsize=%d",
+    syslog(LOG_DEBUG, "%s: left=%zd olen=%zd qsize=%zd",
            __FUNCTION__, *left, olen, qsize);
 #endif
 
@@ -296,7 +296,7 @@ dns_copy_res(struct dhcp_conn_t *conn, int q,
 
 #if(_debug_ > 1)
   if (_options.debug)
-    syslog(LOG_DEBUG, "-> w ttl: %d rdlength: %d/%d", ttl, rdlen, len);
+    syslog(LOG_DEBUG, "-> w ttl: %d rdlength: %d/%zd", ttl, rdlen, len);
 #endif
 
   if (*qmatch == 1 && ttl > _options.uamdomain_ttl) {

--- a/src/redir.c
+++ b/src/redir.c
@@ -1474,7 +1474,7 @@ redir_write(struct redir_socket_t *sock, char *buf, size_t len) {
 
 #if(_debug_ > 1)
   if (_options.debug)
-    syslog(LOG_DEBUG, "redir_write(%d)",len);
+    syslog(LOG_DEBUG, "redir_write(%zd)",len);
 #endif
 
   while (r < len) {
@@ -3709,7 +3709,7 @@ int redir_main(struct redir_t *redir,
                   if ((buflen = safe_read(ctop[0], buffer, bufsize)) > 0) {
 #if(_debug_ > 1)
                     if (_options.debug)
-                      syslog(LOG_DEBUG, "script_read(%d)",buflen);
+                      syslog(LOG_DEBUG, "script_read(%zd)",buflen);
 #endif
                     if (redir_write(&socket, buffer, (size_t) buflen) < 0) {
                       syslog(LOG_ERR, "%s: redir_write() failed!", strerror(errno));
@@ -3717,7 +3717,7 @@ int redir_main(struct redir_t *redir,
                     }
 #if(_debug_ > 1)
                     if (_options.debug)
-                      syslog(LOG_DEBUG, "ssl_write(%d)",buflen);
+                      syslog(LOG_DEBUG, "ssl_write(%zd)",buflen);
 #endif
                   } else {
 #if(_debug_ > 1)

--- a/src/tun.c
+++ b/src/tun.c
@@ -812,7 +812,7 @@ static int tun_decaps_cb(void *ctx, struct pkt_buffer *pb) {
 
 #if(_debug_ > 1)
   if (_options.debug)
-    syslog(LOG_DEBUG, "tun_decaps(idx=%d, len=%d)", tun(c->this, c->idx).ifindex, length);
+    syslog(LOG_DEBUG, "tun_decaps(idx=%d, len=%zd)", tun(c->this, c->idx).ifindex, length);
 #endif
 
   if (length < PKT_IP_HLEN)
@@ -1094,7 +1094,7 @@ int tun_encaps(struct tun_t *tun, uint8_t *pack, size_t len, int idx) {
 #if(_debug_ > 1)
     if (_options.debug)
       syslog(LOG_DEBUG, "writing to tap src=%.2x:%.2x:%.2x:%.2x:%.2x:%.2x "
-             "dst=%.2x:%.2x:%.2x:%.2x:%.2x:%.2x len=%d",
+             "dst=%.2x:%.2x:%.2x:%.2x:%.2x:%.2x len=%zd",
              ethh->src[0],ethh->src[1],ethh->src[2],
              ethh->src[3],ethh->src[4],ethh->src[5],
              ethh->dst[0],ethh->dst[1],ethh->dst[2],
@@ -1109,7 +1109,7 @@ int tun_encaps(struct tun_t *tun, uint8_t *pack, size_t len, int idx) {
 
 #if(_debug_ > 1)
   if (_options.debug)
-    syslog(LOG_DEBUG, "tun_encaps(%s) len=%d", tun(tun,idx).devname, len);
+    syslog(LOG_DEBUG, "tun_encaps(%s) len=%zd", tun(tun,idx).devname, len);
 #endif
 
   result = tun_write(tun, pack, len, idx);


### PR DESCRIPTION
I tried building with debug2 on a 64 bit machine and it kept stopping with messages like '%d expects int, but argument is size_t'