### PR TITLE
Switch calls from strcpy(3) to strlcpy(3)

### DIFF
--- a/src/chilli.c
+++ b/src/chilli.c
@@ -2601,8 +2601,8 @@ int cb_tun_ind(struct tun_t *tun, struct pkt_buffer *pb, int idx) {
             if (_options.debug) {
               char ip[56];
               char snatip[56];
-              strcpy(ip, inet_ntoa(appconn->hisip));
-              strcpy(snatip, inet_ntoa(appconn->natip));
+              strlcpy(ip, inet_ntoa(appconn->hisip), sizeof(ip));
+              strlcpy(snatip, inet_ntoa(appconn->natip), sizeof(snatip));
               syslog(LOG_DEBUG, "SNAT anyip in ARP response from %s to %s",
                      ip, snatip);
             }
@@ -2760,8 +2760,8 @@ int cb_tun_ind(struct tun_t *tun, struct pkt_buffer *pb, int idx) {
     if (_options.debug) {
       char ip[56];
       char snatip[56];
-      strcpy(ip, inet_ntoa(appconn->hisip));
-      strcpy(snatip, inet_ntoa(appconn->natip));
+      strlcpy(ip, inet_ntoa(appconn->hisip), sizeof(ip));
+      strlcpy(snatip, inet_ntoa(appconn->natip), sizeof(snatip));
       syslog(LOG_DEBUG, "SNAT anyip replace %s back to %s; snat was: %s",
              inet_ntoa(dst), ip, snatip);
     }
@@ -2925,7 +2925,7 @@ chilli_learn_location(uint8_t *loc, int loclen,
   memcpy(loc_buff, (char *)loc, loclen);
   loc_buff[loclen]=0;
 
-  strcpy(prev_loc_buff, appconn->s_state.location);
+  strlcpy(prev_loc_buff, appconn->s_state.location, sizeof(prev_loc_buff));
   prev_loc_len = strlen(prev_loc_buff);
 
   if (_options.debug)
@@ -2960,7 +2960,8 @@ chilli_learn_location(uint8_t *loc, int loclen,
 	restart_accounting = 1;
       }
     } else {
-      strcpy(appconn->s_state.pending_location, loc_buff);
+      strlcpy(appconn->s_state.pending_location, loc_buff,
+	sizeof(s_state.pending_location));
     }
   }
 

--- a/src/cmdsock.c
+++ b/src/cmdsock.c
@@ -32,7 +32,7 @@ cmdsock_init() {
 
     local.sun_family = AF_UNIX;
 
-    strcpy(local.sun_path, _options.cmdsocket);
+    strlcpy(local.sun_path, _options.cmdsocket, sizeof(local.sun_path));
     unlink(local.sun_path);
 
     if (bind(cmdsock, (struct sockaddr *)&local,

--- a/src/garden.c
+++ b/src/garden.c
@@ -478,7 +478,7 @@ int pass_throughs_from_string(pass_through *ptlist, uint32_t ptlen,
   if (p3 == NULL)
      return 0;
 
-  strcpy(p3, s);
+  strlcpy(p3, s, sizeof(p3));
   p1 = p3;
 
   if (_options.debug)

--- a/src/main-opt.c
+++ b/src/main-opt.c
@@ -1187,7 +1187,7 @@ int main(int argc, char **argv) {
 
     syslog(LOG_DEBUG, "Macallowed #%d: %s", numargs, args_info.macallowed_arg[numargs]);
 
-    strcpy(p3, args_info.macallowed_arg[numargs]);
+    strlcpy(p3, args_info.macallowed_arg[numargs], sizeof(p3));
     p1 = p3;
     if ((p2 = strchr(p1, ','))) {
       *p2 = '\0';

--- a/src/main-query.c
+++ b/src/main-query.c
@@ -656,7 +656,7 @@ int main(int argc, char **argv) {
     }
 
     remote.sun_family = AF_UNIX;
-    strcpy(remote.sun_path, cmdsock);
+    strlcpy(remote.sun_path, cmdsock, sizeof(remote.sun_path));
 
 #if defined (__FreeBSD__)  || defined (__APPLE__) || defined (__OpenBSD__)
     remote.sun_len = strlen(remote.sun_path) + 1;

--- a/src/main-redir.c
+++ b/src/main-redir.c
@@ -181,7 +181,7 @@ sock_redir_getstate(struct redir_t *redir,
   memset(&remote, 0, sizeof(remote));
 
   remote.sun_family = AF_UNIX;
-  strcpy(remote.sun_path, filedest);
+  strlcpy(remote.sun_path, filedest, sizeof(remote.sun_path));
 
 #if defined (__FreeBSD__)  || defined (__APPLE__) || defined (__OpenBSD__)
   remote.sun_len = strlen(remote.sun_path) + 1;

--- a/src/sample-mod.c
+++ b/src/sample-mod.c
@@ -34,7 +34,7 @@ static int module_initialize(char *conf, char isReload) {
 
     local.sun_family = AF_UNIX;
 
-    strcpy(local.sun_path, SOCK_PATH);
+    strlcpy(local.sun_path, SOCK_PATH, sizeof(local.sun_patch));
     unlink(local.sun_path);
 
     if (bind(fd, (struct sockaddr *)&local,


### PR DESCRIPTION
While the previously used calls to safe_strcpy() were switched to strlcpy(), there were some calls to strcpy() which were left unconverted.