### PR TITLE
Remove the AC_CHECK_HEADER_STDBOOL macro as it is redundant.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,7 +107,6 @@ AC_CHECK_HEADERS([resolv.h net/route.h net/if.h net/if_arp.h net/if_tun.h net/et
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
-AC_CHECK_HEADER_STDBOOL
 AC_TYPE_UID_T
 AC_C_INLINE
 AC_TYPE_INT16_T


### PR DESCRIPTION
From the autoconf docs:
"This macro is intended for use by Gnulib (see Gnulib) and other packages that
supply a substitute stdbool.h on platforms lacking a conforming one."

Macro introduced via autoupdate, flagged an error in travis build output as
macro is not available there.

	modified:   configure.ac