### PR TITLE
radius/redir: Fix usage of already closed fd and stream used in logging

### DIFF
--- a/src/radius.c
+++ b/src/radius.c
@@ -1383,23 +1383,27 @@ int radius_init_q(struct radius_t *this, int size) {
  */
 int
 radius_free(struct radius_t *this) {
+  int fd;
+
   if (this->queue) {
     free(this->queue);
   }
   if (this->urandom_fp) {
+    fd = fileno(this->urandom_fp);
     if (fclose(this->urandom_fp)) {
       syslog(LOG_ERR, "radius: %s: fclose(urandom_fp=%d) failed!",
-             strerror(errno), fileno(this->urandom_fp));
+             strerror(errno), fd);
     }
   }
+  fd = this->fd;
   if (close(this->fd)) {
-    syslog(LOG_ERR, "radius: %s: close(fd=%d) failed!", strerror(errno),
-           this->fd);
+    syslog(LOG_ERR, "radius: %s: close(fd=%d) failed!", strerror(errno), fd);
   }
 #ifdef ENABLE_RADPROXY
+  fd = this->proxyfd;
   if (this->proxyfd > 0 && close(this->proxyfd)) {
      syslog(LOG_ERR, "radius: %s: close(proxyfd=%d) failed!", strerror(errno),
-            this->proxyfd);
+            fd);
   }
 #endif
   free(this);

--- a/src/redir.c
+++ b/src/redir.c
@@ -1857,10 +1857,13 @@ int redir_ipc(struct redir_t *redir) {
 /* Free instance of redir */
 int redir_free(struct redir_t *redir) {
   int n;
+  int fd;
+
   for (n = 0; n < 2 && redir->fd[n]; n++) {
+    fd = redir->fd[n];
     if (safe_close(redir->fd[n])) {
       syslog(LOG_ERR, "redir: %s: close(fd=%d[%d]) failed", strerror(errno),
-	     redir->fd[n], n);
+	     fd, n);
     }
   }
 


### PR DESCRIPTION
It's a fix for a bug I've introduced in b7190800b. Using fd/stream after
close/fclose is not a good idea, at least not much helpful for debugging
as fileno() would return always -1 on the invalid stream.

Thanks to Sevan for noticing it.

Signed-off-by: Petr Štetiar <ynezz@true.cz>