### PR TITLE
Fix compile error with --enable-location

### DIFF
--- a/src/chilli.c
+++ b/src/chilli.c
@@ -2961,7 +2961,7 @@ chilli_learn_location(uint8_t *loc, int loclen,
       }
     } else {
       strlcpy(appconn->s_state.pending_location, loc_buff,
-	sizeof(s_state.pending_location));
+	sizeof(appconn->s_state.pending_location));
     }
   }
 


### PR DESCRIPTION
Fix error issue #167 :
```C
chilli.c: In function 'chilli_learn_location':
chilli.c:2964:9: error: 's_state' undeclared (first use in this
      function)
sizeof(s_state.pending_location));
```

s_state is declared in the appconn.

```C
sizeof(appconn->s_state.pending_location);
```

Signed-off-by: Baligh GUESMI gasmibal@gmail.com