### PR TITLE
Do not reopen the socket just because writing would block.

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -941,8 +941,6 @@ ssize_t net_write_eth(net_interface *netif, void *d, size_t dlen, struct sockadd
     switch (errno) {
       case EWOULDBLOCK:
         syslog(LOG_ERR, "%s: packet dropped due to congestion", strerror(errno));
-        if (!_options.uid)
-          net_reopen(netif);
         break;
 
 #ifdef ENETDOWN


### PR DESCRIPTION
Reopening the socket will cause incoming packets to be dropped and can
cause a flood of read errors spamming the logging facility and creating
a high peak in the load.

Signed-off-by: Benjamin Berg <benjamin@sipsolutions.net>
Signed-off-by: René van Weert <r.vanweert@sowifi.com>