### PR TITLE
Replace obsolete macros with current equivalents.

### DIFF
--- a/acsite.m4
+++ b/acsite.m4
@@ -2,11 +2,8 @@ dnl
 AC_DEFUN(AC_LBL_TPACKET_STATS,
    [AC_MSG_CHECKING(if if_packet.h has tpacket_stats defined)
    AC_CACHE_VAL(ac_cv_lbl_tpacket_stats,
-   AC_TRY_COMPILE([
-#  include <linux/if_packet.h>],
-   [struct tpacket_stats stats],
-   ac_cv_lbl_tpacket_stats=yes,
-   ac_cv_lbl_tpacket_stats=no))
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#  include <linux/if_packet.h>]], [[struct tpacket_stats stats]])],[ac_cv_lbl_tpacket_stats=yes],[ac_cv_lbl_tpacket_stats=no]))
    AC_MSG_RESULT($ac_cv_lbl_tpacket_stats)
    if test $ac_cv_lbl_tpacket_stats = yes; then
        AC_DEFINE(HAVE_TPACKET_STATS,1,[if if_packet.h has tpacket_stats defined])
@@ -15,12 +12,9 @@ AC_DEFUN(AC_LBL_TPACKET_STATS,
 AC_DEFUN(AC_LBL_LINUX_TPACKET_AUXDATA_TP_VLAN_TCI,
     [AC_MSG_CHECKING(if tpacket_auxdata struct has tp_vlan_tci member)
     AC_CACHE_VAL(ac_cv_lbl_linux_tpacket_auxdata_tp_vlan_tci,
-	AC_TRY_COMPILE([
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #	include <sys/types.h>
-#	include <linux/if_packet.h>],
-	[u_int i = sizeof(((struct tpacket_auxdata *)0)->tp_vlan_tci)],
-	ac_cv_lbl_linux_tpacket_auxdata_tp_vlan_tci=yes,
-	ac_cv_lbl_linux_tpacket_auxdata_tp_vlan_tci=no))
+#	include <linux/if_packet.h>]], [[u_int i = sizeof(((struct tpacket_auxdata *)0)->tp_vlan_tci)]])],[ac_cv_lbl_linux_tpacket_auxdata_tp_vlan_tci=yes],[ac_cv_lbl_linux_tpacket_auxdata_tp_vlan_tci=no]))
     AC_MSG_RESULT($ac_cv_lbl_linux_tpacket_auxdata_tp_vlan_tci)
     if test $ac_cv_lbl_linux_tpacket_auxdata_tp_vlan_tci = yes ; then
 	    HAVE_LINUX_TPACKET_AUXDATA=tp_vlan_tci

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.57])
+AC_PREREQ([2.59])
 AC_INIT([coova-chilli],[1.3.1.3],[support@coova.com])
 AC_CONFIG_SRCDIR([src/chilli.c])
 
 AM_INIT_AUTOMAKE
 
-AM_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 
 AC_CONFIG_MACRO_DIR([m4])
 


### PR DESCRIPTION
Bump AC_PREREQ to 2.59 (the earliest version I could find to reference
AC_CONFIG_HEADERS)

	modified:   acsite.m4
	modified:   configure.ac