### PR TITLE
fix bad substitution error message when parsing functions file

### DIFF
--- a/conf/functions.in
+++ b/conf/functions.in
@@ -83,7 +83,7 @@ net		$HS_NETWORK/$HS_NETMASK
 uamlisten	$HS_UAMLISTEN
 uamport         $HS_UAMPORT
 dhcpif		$HS_LANIF
-uamallowed	"${$HS_UAMSERVER}$webadmin$uamallow"
+uamallowed	"$HS_UAMSERVER$webadmin$uamallow"
 uamanydns
 $(cat $configs1)
 $HS_RAW_CONFIG1


### PR DESCRIPTION
on daemon start I get: 
Starting chilli: /etc/chilli/functions: line 77: # THIS FILE IS AUTOMATICALLY GENERATED
cmdsocket       $CMDSOCK
unixipc         $IPCFILE
pidfile         $PIDFILE
net             $HS_NETWORK/$HS_NETMASK
uamlisten       $HS_UAMLISTEN
uamport         $HS_UAMPORT
dhcpif          $HS_LANIF
uamallowed      "${$HS_UAMSERVER}$webadmin$uamallow"
uamanydns
$(cat $configs1)
$HS_RAW_CONFIG1
: bad substitution
