### PR TITLE
add override of username if received in an Access-Accept packet

### DIFF
--- a/src/chilli.c
+++ b/src/chilli.c
@@ -4419,6 +4419,7 @@ int cb_radius_auth_conf(struct radius_t *radius,
 
   struct radius_attr_t *stateattr = NULL;
   struct radius_attr_t *classattr = NULL;
+  struct radius_attr_t *uidattr = NULL;
 
 #ifdef ENABLE_RADPROXY
   int instance = 0;
@@ -4664,6 +4665,18 @@ int cb_radius_auth_conf(struct radius_t *radius,
   if (_options.debug)
     syslog(LOG_DEBUG, "Received RADIUS Access-Accept");
 #endif
+
+  if (!radius_getattr(pack, &uidattr, RADIUS_ATTR_USER_NAME, 0, 0, 0)) {
+    if (uidattr->l-2 < USERNAMESIZE) {
+      memcpy(appconn->s_state.redir.username,
+        (char *)uidattr->v.t, uidattr->l-2);
+        appconn->s_state.redir.username[uidattr->l-2]=0;
+    }
+#if(_debug_)
+    if (_options.debug)
+      syslog(LOG_DEBUG, "Received User-Name override from RADIUS Access-Accept: %s", appconn->s_state.redir.username);
+#endif
+  }
 
   /* Class */
   if (!radius_getattr(pack, &classattr, RADIUS_ATTR_CLASS, 0, 0, 0)) {


### PR DESCRIPTION
according to https://tools.ietf.org/html/rfc2865, section 5.1, the User-Name attribute may be sent in an Access-Accept packet the client should use the given username for the accounting session that follows.

I came across this in the context of a scenario where a wifi user is moving from one access point to another and I need to avoid re-authentication. So I configured coova to do macauth and the radius server will search for an open session for the client MAC and return the real authenticated username in the Access-Accept packet. The client will start a new accounting session, but it will still be tracked with the real username and thus, the account restrictions will apply.