### PR TITLE
FIX error in loading binary status file.

### DIFF
--- a/src/chilli.c
+++ b/src/chilli.c
@@ -1232,10 +1232,13 @@ static int checkconn() {
 
 void chilli_freeconn() {
   struct app_conn_t *conn, *c;
+  struct dhcp_conn_t *d = NULL;
 
   for (conn = firstusedconn; conn; ) {
     c = conn;
     conn = conn->next;
+    d = (struct dhcp_conn_t *)c->dnlink;
+    if (d) d->peer = NULL;
     free(c);
   }
 


### PR DESCRIPTION
When coova-chilli is about to exit, it release all app_conn_t object. But do not update references handled by dhcp_conn_t object.
When creating the binary status file, a garbage app_conn_t object will be stored associated to the dhcp_conn_t object.
This FIX is just about updating the references whithin dhcp_conn_t objects. Will fix #195 too.
 
Signed-off-by: Baligh GUESMI