### PR TITLE
Disable SSLv2 and SSLv3 protocol. Add sslciphers option

### DIFF
--- a/doc/chilli.conf.5.in
+++ b/doc/chilli.conf.5.in
@@ -934,6 +934,10 @@ Defines the location of the PEM formatted certificate file.
 Defines the location of the PEM formatted CA certificate file.
 
 .TP
+.BI sslciphers " ciphers"
+Defines the ciphers that will be used.
+
+.TP
 .B redirssl
 When set, HTTPS requests by unauthorized clients get hijacked instead of dropped.
 Requires at least

--- a/src/cmdline.ggo
+++ b/src/cmdline.ggo
@@ -257,6 +257,7 @@ option "sslkeyfile"  - "SSL private key file in PEM format" string no
 option "sslkeypass"  - "SSL private key password" string no
 option "sslcertfile" - "SSL certificate file in PEM format" string no
 option "sslcafile"   - "SSL CA certificate file in PEM format" string no
+option "sslciphers"   - "SSL ciphers to use" string no
 option "unixipc"     - "The UNIX IPC Filename to use when compiled with --with-unixipc" string no
 option "uamallowpost" - "Enable to allow a HTTP POST to the standard uamport interface" flag off
 option "natip"     - "IP to use when doing nat on WAN (routeidx)" string no

--- a/src/main-opt.c
+++ b/src/main-opt.c
@@ -1238,6 +1238,7 @@ int main(int argc, char **argv) {
   _options.sslkeypass = STRDUP(args_info.sslkeypass_arg);
   _options.sslcertfile = STRDUP(args_info.sslcertfile_arg);
   _options.sslcafile = STRDUP(args_info.sslcafile_arg);
+  _options.sslciphers = STRDUP(args_info.sslciphers_arg);
 #endif
 
 #ifdef USING_IPC_UNIX

--- a/src/options.c
+++ b/src/options.c
@@ -324,6 +324,7 @@ int options_fromfd(int fd, bstring bt) {
   if (!option_s_l(bt, &o.sslkeypass)) return 0;
   if (!option_s_l(bt, &o.sslcertfile)) return 0;
   if (!option_s_l(bt, &o.sslcafile)) return 0;
+  if (!option_s_l(bt, &o.sslciphers)) return 0;
 #endif
 #ifdef USING_IPC_UNIX
   if (!option_s_l(bt, &o.unixipc)) return 0;
@@ -524,6 +525,7 @@ int options_save(char *file, bstring bt) {
   if (!option_s_s(bt, &o.sslkeypass)) return 0;
   if (!option_s_s(bt, &o.sslcertfile)) return 0;
   if (!option_s_s(bt, &o.sslcafile)) return 0;
+  if (!option_s_s(bt, &o.sslciphers)) return 0;
 #endif
 #ifdef USING_IPC_UNIX
   if (!option_s_s(bt, &o.unixipc)) return 0;

--- a/src/options.h
+++ b/src/options.h
@@ -354,6 +354,7 @@ struct options_t {
   char *sslkeypass;
   char *sslcertfile;
   char *sslcafile;
+  char *sslciphers;
 #endif
 
   /* local content */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -125,13 +125,13 @@ _openssl_env_init(openssl_env *env, char *engine, int server) {
    * If ``server'' is 1, the environment is that of a SSL
    * server.
    */
-  if (server) {
-    env->meth = SSLv23_server_method();
-  } else {
-    env->meth = TLSv1_client_method();
-  }
+  const long options = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION;
+  env->meth = SSLv23_method();
   env->ctx = SSL_CTX_new(env->meth);
-  SSL_CTX_set_options(env->ctx, SSL_OP_ALL);
+  SSL_CTX_set_options(env->ctx, options);
+  if (_options.sslciphers) {
+    SSL_CTX_set_cipher_list(env->ctx, _options.sslciphers);
+  }
 #ifdef HAVE_OPENSSL_ENGINE
   if (engine) {
  retry:


### PR DESCRIPTION
This patch:

* Disables SSLv2 and SSLv3 since they are no more secure (like POODLE, DROWN, etc).
* Allow explicitly specify SSL ciphers (like apache and other do) via sslciphers configuration option. This enable users to exclude some low ciphers if they want.
 