### PR TITLE
Switch to using SSL_CTX_use_certificate_chain_file() so that certific…

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -92,7 +92,7 @@ openssl_verify_peer(openssl_env *env, int mode) {
 int
 openssl_use_certificate(openssl_env *env, char *file) {
   if (file)
-    if (SSL_CTX_use_certificate_file(env->ctx, file, SSL_FILETYPE_PEM) > 0)
+    if (SSL_CTX_use_certificate_chain_file(env->ctx, file) > 0)
       return 1;
   syslog(LOG_ERR, "%s: could not load certificate file %s\n", strerror(errno), file);
   return 0;


### PR DESCRIPTION
…ate bundles

can be used. Patch from @daniel-sullivan, resolves #204

	modified:   src/ssl.c