### PR TITLE
Fix build failures with ipt_coova kernel module and coova-chilli source

### DIFF
--- a/src/chilli.c
+++ b/src/chilli.c
@@ -4347,7 +4347,10 @@ static int chilliauth_cb(struct radius_t *radius,
 	    while (!differ && r1 > 0 && r2 > 0);
 	  }
 
-	  if (oldfd) safe_close(oldfd); oldfd=0;
+	  if (oldfd) {
+		  safe_close(oldfd);
+		  oldfd=0;
+	  }
 
 	  if (differ) {
             if (_options.debug)

--- a/src/linux/Makefile
+++ b/src/linux/Makefile
@@ -1,6 +1,7 @@
-KERNEL_DIR ?= /usr/src/linux-headers-$(shell uname -r)
+#check if this makefile is being processed from kbuild
+ifeq ($(KERNELRELEASE),)
 
-obj-m += xt_coova.o
+KERNEL_DIR ?= /lib/modules/$(shell uname -r)/build
 
 all: libxt_coova.so
 	make -C ${KERNEL_DIR} M=$$PWD;
@@ -30,3 +31,8 @@ install: modules_install libxt_coova.so
 distdir:
 
 distclean: clean
+
+else
+#kbuild variables for xtables coova module
+obj-m += xt_coova.o
+endif

--- a/src/linux/Makefile
+++ b/src/linux/Makefile
@@ -22,7 +22,7 @@ lib%.so: lib%.o
 	$(CC) $(CFLAGS) -shared -o $@ $^;
 
 lib%.o: lib%.c
-	$(CC) $(CFLAGS) -fPIC -O2 -Wall -I${KERNEL_DIR}/include -D_INIT=lib$*_init -c -o $@ $<;
+	$(CC) $(CFLAGS) -fPIC -O2 -Wall -D_INIT=lib$*_init -c -o $@ $<;
 
 install: modules_install libxt_coova.so
 	mkdir -p $(DESTDIR)/lib/xtables/

--- a/src/redir.c
+++ b/src/redir.c
@@ -3277,9 +3277,11 @@ pid_t redir_fork(int in, int out) {
     }
 
 #if defined(F_DUPFD)
-    if (fcntl(in,F_GETFL,0) == -1) return -1; safe_close(0);
+    if (fcntl(in,F_GETFL,0) == -1) return -1;
+    safe_close(0);
     if (fcntl(in,F_DUPFD,0) == -1) return -1;
-    if (fcntl(out,F_GETFL,1) == -1) return -1; safe_close(1);
+    if (fcntl(out,F_GETFL,1) == -1) return -1;
+    safe_close(1);
     if (fcntl(out,F_DUPFD,1) == -1) return -1;
 #else
     if (dup2(in,0) == -1) return -1;


### PR DESCRIPTION
This pull request fixes bunch of build error that were encountered while building coova-chilli on fedora 24 with kernel 4.7.2 and GCC-6.0. These errors were due usage of non-standard kernel/uapi header while building the ip_coova module and misleading indentation used in the coova-chilli source that was flagged by gcc6 newly introduced -Wmisleading-indentation warning.