### PR TITLE
chilli: Fix a build error with --enable-json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 before_install: 
  - sudo apt-get update -qq
- - sudo apt-get install -y gengetopt
+ - sudo apt-get install -y gengetopt libjson0-dev
  - ./bootstrap
 script:
  - ./configure --enable-largelimits --enable-proxyvsa --enable-miniportal

--- a/configure.ac
+++ b/configure.ac
@@ -210,6 +210,12 @@ AC_ARG_ENABLE(json, [AS_HELP_STRING([--enable-json],[Enable support for JSON])],
 
 if test x"$enable_json" = xyes; then
    AC_DEFINE(ENABLE_JSON,1,[Define to enable Chilli JSON])
+   AC_CHECK_LIB([json-c], [json_object_new_object],
+	      [AC_SUBST([LIBJSON], ["-ljson-c"])],
+				   [AC_CHECK_LIB([json], [json_object_new_object],
+				   [AC_SUBST([LIBJSON], ["-ljson"])],
+				   [AC_MSG_FAILURE(
+				   [--enable-json was given, but test for libjson failed])],)])
 fi
 
 AC_ARG_ENABLE(debug, [AS_HELP_STRING([--disable-debug],[Disable debugging messages])], 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,7 +39,7 @@ chilli_query_SOURCES = main-query.c
 chilli_opt_SOURCES = main-opt.c 
 
 libchilli_la_LIBADD = $(top_builddir)/bstring/libbstring.la 
-LDADD = libchilli.la ${LIBRT} $(top_builddir)/bstring/libbstring.la 
+LDADD = libchilli.la ${LIBRT} $(top_builddir)/bstring/libbstring.la ${LIBJSON}
 
 if WITH_MINICONFIG
 chilli_opt_SOURCES += cmdline.mini.c


### PR DESCRIPTION
This fixes a build error that occurs when --enable-json config flag is
set and libjson-c is not available. This adds a check in configure.ac
for availability of libjson-c library.

Also libjson-c was not present in the list of linked libraries for chilli
binary. Hence a linker error complaining about missing json_object_xxx
functions used to occur. To fix this a new m4 macro named LIBJSON is
added to configure.ac that expands to -ljson-c and is added to list of
libraries to be linked to chill in src/Makefile.am.

Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>