### PR TITLE
Allow --enable-location without --enable-proxyvsa

### DIFF
--- a/src/chilli.c
+++ b/src/chilli.c
@@ -548,7 +548,7 @@ double mainclock_diffd(struct timespec * past) {
 }
 
 uint8_t* chilli_called_station(struct session_state *state) {
-#ifdef ENABLE_PROXYVSA
+#ifdef ENABLE_LOCATION
   if (_options.location_copy_called && state->redir.calledlen) {
     return state->redir.called;
   }
@@ -3085,8 +3085,10 @@ static int
 chilli_proxy_radlocation(struct radius_packet_t *pack,
 			 struct app_conn_t *appconn, char force) {
   struct radius_attr_t *attr = 0;
+#ifdef ENABLE_PROXYVSA
   uint8_t * vsa = appconn->s_state.redir.vsa;
   int instance=0;
+#endif
 
   if (_options.location_copy_called) {
     if (!radius_getattr(pack, &attr, RADIUS_ATTR_CALLED_STATION_ID, 0, 0, 0)) {
@@ -3099,6 +3101,7 @@ chilli_proxy_radlocation(struct radius_packet_t *pack,
     }
   }
 
+#ifdef ENABLE_PROXYVSA
   do {
     attr=NULL;
     if (!radius_getattr(pack, &attr, RADIUS_ATTR_VENDOR_SPECIFIC, 0, 0,
@@ -3120,6 +3123,7 @@ chilli_proxy_radlocation(struct radius_packet_t *pack,
 #endif
     }
   } while (attr);
+#endif
 
 #ifdef ENABLE_LOCATION
   if (_options.proxy_loc[0].attr) {

--- a/src/chilli.h
+++ b/src/chilli.h
@@ -287,6 +287,8 @@ void child_killall(int sig);
 
 #ifdef ENABLE_PROXYVSA
 int radius_addvsa(struct radius_packet_t *pack, struct redir_state *state);
+#endif
+#if defined(ENABLE_LOCATION) || defined(ENABLE_PROXYVSA)
 int chilli_learn_location(uint8_t *loc, int loclen,
 			  struct app_conn_t *appconn, char force);
 #endif

--- a/src/main-opt.c
+++ b/src/main-opt.c
@@ -541,7 +541,7 @@ int main(int argc, char **argv) {
   _options.bwbucketminsize = args_info.bwbucketminsize_arg;
 #endif
 
-#ifdef ENABLE_PROXYVSA
+#if defined(ENABLE_PROXYVSA) || defined(ENABLE_LOCATION)
   _options.vlanlocation = args_info.vlanlocation_flag;
   _options.location_stop_start = args_info.locationstopstart_flag;
   _options.location_copy_called = args_info.locationcopycalled_flag;
@@ -1394,7 +1394,7 @@ int main(int argc, char **argv) {
   _options.ieee8021q_only = args_info.only8021q_flag;
   _options.vlanupdate = STRDUP(args_info.vlanupdate_arg);
 #endif
-#ifdef ENABLE_PROXYVSA
+#if defined(ENABLE_PROXYVSA) || defined(ENABLE_LOCATION)
   _options.locationupdate = STRDUP(args_info.locationupdate_arg);
 #endif
   _options.nochallenge = args_info.nochallenge_flag;

--- a/src/options.c
+++ b/src/options.c
@@ -279,7 +279,7 @@ int options_fromfd(int fd, bstring bt) {
 #ifdef ENABLE_IEEE8021Q
   if (!option_s_l(bt, &o.vlanupdate)) return 0;
 #endif
-#ifdef ENABLE_PROXYVSA
+#if defined(ENABLE_PROXYVSA) || defined(ENABLE_LOCATION)
   if (!option_s_l(bt, &o.locationupdate)) return 0;
 #endif
 
@@ -479,7 +479,7 @@ int options_save(char *file, bstring bt) {
 #ifdef ENABLE_IEEE8021Q
   if (!option_s_s(bt, &o.vlanupdate)) return 0;
 #endif
-#ifdef ENABLE_PROXYVSA
+#if defined(ENABLE_PROXYVSA) || defined(ENABLE_LOCATION)
   if (!option_s_s(bt, &o.locationupdate)) return 0;
 #endif
 

--- a/src/options.h
+++ b/src/options.h
@@ -274,7 +274,7 @@ struct options_t {
   uint8_t proxymacaccept:1;         /* Auto-accept non-EAP requests on proxy port */
   uint8_t proxyonacct:1;
 #endif
-#ifdef ENABLE_PROXYVSA
+#if defined(ENABLE_LOCATION) || defined(ENABLE_PROXYVSA)
   uint8_t vlanlocation:1;
   uint8_t location_stop_start:1;
   uint8_t location_copy_called:1;
@@ -340,7 +340,7 @@ struct options_t {
   uint32_t challengetimeout;
   uint32_t challengetimeout2;
 
-#ifdef ENABLE_PROXYVSA
+#if defined(ENABLE_LOCATION) || defined(ENABLE_PROXYVSA)
 #define PROXYVSA_ATTR_CNT 4
   struct {
     uint32_t attr_vsa;

--- a/src/radius.c
+++ b/src/radius.c
@@ -56,7 +56,7 @@ void radius_addcalledstation(struct radius_t *this,
   uint8_t b[32];
   uint8_t *mac = NULL;
 
-#ifdef ENABLE_PROXYVSA
+#if defined(ENABLE_PROXYVSA) || defined(ENABLE_LOCATION)
   if (state->redir.calledlen) {
     radius_addattr(this, pack, RADIUS_ATTR_CALLED_STATION_ID, 0, 0, 0,
                    state->redir.called, state->redir.calledlen);

--- a/src/session.h
+++ b/src/session.h
@@ -103,10 +103,12 @@ struct redir_state {
   char acceptlanguage[128];
 #endif
 
-#ifdef ENABLE_PROXYVSA
-#define RADIUS_PROXYVSA 256
+#if defined(ENABLE_LOCATION) || defined(ENABLE_PROXYVSA)
   uint8_t called[RADIUS_ATTR_VLEN];
   uint8_t calledlen;
+#endif
+#ifdef ENABLE_PROXYVSA
+#define RADIUS_PROXYVSA 256
   uint8_t vsa[RADIUS_PROXYVSA];
   size_t vsalen;
 #endif


### PR DESCRIPTION
Previously, --enable-location was dependant on --enable-proxyvsa, i.e. it
used fields/functions ifdef-ed away on ENABLE_PROXYVSA

This patch replaces most of them by
"#if defined(ENABLE_LOCATION) || defined(ENABLE_PROXYVSA)"

Since I don't use proxyvsa (mostly because of issue #262 ), I don't know
if proxyvsa needs alls these fields, or if they could be guarded by
"#ifdef ENABLE_LOCATION"

Also I only tested this with proxyloc=32 (NASIdentifier) on a cisco-AP,
which is a non-VSA. Tracking location with a VSA might eventually not work.

Signed-off-by: Tim Riemenschneider <git@tim-riemenschneider.de>