### PR TITLE
Built with 4.4.14 fails

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -169,7 +169,7 @@
 #include <net/if_tun.h>
 #endif
 
-#ifdef HAVE_NET_ETHERNET_H
+#if defined(HAVE_NET_ETHERNET_H) && !defined(__linux__)
 #include <net/ethernet.h>
 #endif
 


### PR DESCRIPTION
ethernet.h contents defined in linux/if_ether.h

fixes #291