### PR TITLE
Fix sslkeypass not working #297

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -167,7 +167,7 @@ _openssl_env_init(openssl_env *env, char *engine, int server) {
 static int _openssl_passwd(char *buf, int size, int rwflag, void *ud) {
   strlcpy(buf, _options.sslkeypass, size);
   memset(_options.sslkeypass,'x',strlen(_options.sslkeypass));
-  return 0;
+  return strlen(buf);
 }
 #endif
 


### PR DESCRIPTION
This patch is about passphrase support in the openssl, which is contain
a problem in the password callback return value. This function must
return the length of the password to the calling function.
Thanks to @miglio

Signed-off-by: Baligh GUESMI <gasmibal@gmail.com>