### PR TITLE
Switch from des_ to DES_ prefix functions.

### DIFF
--- a/src/ms_chap.c
+++ b/src/ms_chap.c
@@ -96,18 +96,18 @@ MakeKey(u_char *key, u_char *des_key)
   des_key[6] = Get7Bits(key, 42);
   des_key[7] = Get7Bits(key, 49);
 
-  des_set_odd_parity((des_cblock *)des_key);
+  DES_set_odd_parity((DES_cblock *)des_key);
 }
 
 static void /* IN 8 octets IN 7 octest OUT 8 octets */
 DesEncrypt(u_char *clear, u_char *key, u_char *cipher)
 {
-  des_cblock		des_key;
-  des_key_schedule	key_schedule;
+  DES_cblock		des_key;
+  DES_key_schedule	key_schedule;
 
   MakeKey(key, des_key);
-  des_set_key(&des_key, key_schedule);
-  des_ecb_encrypt((des_cblock *)clear, (des_cblock *)cipher, key_schedule, 1);
+  DES_set_key(&des_key, &key_schedule);
+  DES_ecb_encrypt((DES_cblock *)clear, (DES_cblock *)cipher, &key_schedule, 1);
 }
 
 #define LENGTH 20


### PR DESCRIPTION
The original des_ prefixed functions were renamed to use a DES_prefix in OpenSSL 0.9.7.
This enables linking against modern OpenSSL forks such as LibreSSL.