### PR TITLE
Incorrect usage of setsockopt TCP_NODELAY

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1261,7 +1261,7 @@ int net_open_eth(net_interface *netif) {
     coe(netif->fd);
 
     option = 1;
-    if (net_setsockopt(netif->fd, SOL_SOCKET, TCP_NODELAY,
+    if (net_setsockopt(netif->fd, IPPROTO_TCP, TCP_NODELAY,
 		       &option, sizeof(option)) < 0)
       return -1;
 


### PR DESCRIPTION
setsockopt() with TCP_NODELAY incorrectly used SOL_SOCKET protocol level
which lead to setting SO_DEBUG. Changed level to IPPROTO_TCP.

Pull request for issue #357.