### PR TITLE
setsockopt failed after last commit #368

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1260,19 +1260,6 @@ int net_open_eth(net_interface *netif) {
     ndelay_on(netif->fd);
     coe(netif->fd);
 
-    /* Try to set TCP_NODELAY for stream socket type */
-    {
-      int type;
-      unsigned int typelen = sizeof(type);
-
-      if ((getsockopt(netif->fd, SOL_SOCKET, SO_TYPE, &type, &typelen) == 0) &&
-          (type == SOCK_STREAM)) {
-        option = 1;
-        if (net_setsockopt(netif->fd, IPPROTO_TCP, TCP_NODELAY, &option, sizeof(option)) < 0)
-          return -1;
-      }
-    }
-
     /* Enable reception and transmission of broadcast frames */
     option = 1;
     if (net_setsockopt(netif->fd, SOL_SOCKET, SO_BROADCAST,


### PR DESCRIPTION
Remove setsockopt() call.
The socket is always created as SOCK_RAW, and the only (commented-out)
alternative is SOCK_DGRAM. Neither can have TCP_NODELAY aplied.

Signed-off-by: Baligh GUESMI <gasmibal@gmail.com>