### PR TITLE
Fix build with ENABLE_SESSGARDEN but not HAVE_PATRICIA

### DIFF
--- a/src/garden.c
+++ b/src/garden.c
@@ -80,7 +80,7 @@ int garden_print_appconn(struct app_conn_t *appconn, void *d) {
       patricia_process(appconn->ptree, cb);
     } else
 #endif
-      garden_print_list(fd,
+    garden_print_list(fd,
 			appconn->s_params.pass_throughs,
 			appconn->s_params.pass_through_count);
   }


### PR DESCRIPTION
Fix following error at build time:

garden.c: In function ‘garden_print_appconn’:
garden.c:77:5: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
     if (!safe_write(fd, line, strlen(line))) /* error */;
     ^~
garden.c:83:7: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
       garden_print_list(fd,
       ^~~~~~~~~~~~~~~~~

Fixes #413