### PR TITLE
Fix init script

### DIFF
--- a/conf/chilli.in
+++ b/conf/chilli.in
@@ -63,7 +63,7 @@ start() {
 
     test ${HS_LANIF_KEEPADDR:-0} -eq 0 && ifconfig $HS_LANIF 0.0.0.0
 
-    daemon $exec -c $CONFIG
+    daemon -- $exec -c $CONFIG
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile


### PR DESCRIPTION
Tell daemon helper not to parse any more options.

Fixes #416