### PR TITLE
fix compilation with --enable-chilliredir and musl

### DIFF
--- a/src/main-redir.c
+++ b/src/main-redir.c
@@ -508,20 +508,13 @@ check_regex(regex_t *re, char *regex, char *s) {
   syslog(LOG_DEBUG, "Checking %s =~ %s", s, regex);
 #endif
 
-#if defined (__FreeBSD__) || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
-  if (!re->re_g)
-#else
-    if (!re->allocated)
-#endif
-    {
-      if ((ret = regcomp(re, regex, REG_EXTENDED | REG_NOSUB)) != 0) {
-        char error[512];
-        regerror(ret, re, error, sizeof(error));
-        syslog(LOG_ERR, "regcomp(%s) failed (%s)", regex, error);
-        regex[0] = 0;
-        return -1;
-      }
-    }
+  if ((ret = regcomp(re, regex, REG_EXTENDED | REG_NOSUB)) != 0) {
+    char error[512];
+    regerror(ret, re, error, sizeof(error));
+    syslog(LOG_ERR, "regcomp(%s) failed (%s)", regex, error);
+    regex[0] = 0;
+    return -1;
+  }
 
   if ((ret = regexec(re, s, 0, 0, 0)) == 0) {
 

--- a/src/options.c
+++ b/src/options.c
@@ -377,7 +377,7 @@ int options_fromfd(int fd, bstring bt) {
 
 #ifdef ENABLE_CHILLIREDIR
   for (i = 0; i < MAX_REGEX_PASS_THROUGHS; i++) {
-#if defined (__FreeBSD__) || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+#if defined (__linux__) || defined (__FreeBSD__) || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
     regfree(&_options.regex_pass_throughs[i].re_host);
     regfree(&_options.regex_pass_throughs[i].re_path);
     regfree(&_options.regex_pass_throughs[i].re_qs);


### PR DESCRIPTION
musl lacks `allocated` member on `struct re_pattern_buffer` (`regex_t`)
(https://fossies.org/dox/musl-1.1.20/structre__pattern__buffer.html).

Patch inspired by @drkhosla's comment at issue https://github.com/coova/coova-chilli/issues/200#issuecomment-253497070