### PR TITLE
Fix RADIUS proxy feature (wrong reply socket)

### DIFF
--- a/src/radius.c
+++ b/src/radius.c
@@ -1526,6 +1526,26 @@ int radius_pkt_send(struct radius_t *this,
   return 0;
 }
 
+#ifdef ENABLE_RADPROXY
+/*
+ * radius_pkt_send_proxy()
+ * Send of a proxied response
+ */
+int radius_pkt_send_proxy(struct radius_t *this,
+      struct radius_packet_t *pack,
+      struct sockaddr_in *peer) {
+
+  size_t len = ntohs(pack->length);
+
+  if (sendto(this->proxyfd, pack, len, 0,(struct sockaddr *) peer,
+       sizeof(struct sockaddr_in)) < 0) {
+    syslog(LOG_ERR, "%s: sendto() failed!", strerror(errno));
+    return -1;
+  }
+
+  return 0;
+}
+#endif
 
 /*
  * radius_req()
@@ -1592,7 +1612,7 @@ int radius_resp(struct radius_t *this,
 				this->proxysecret,
 				this->proxysecretlen);
 
-  return radius_pkt_send(this, pack, peer);
+  return radius_pkt_send_proxy(this, pack, peer);
 }
 #endif
 

--- a/src/radius.h
+++ b/src/radius.h
@@ -303,6 +303,12 @@ int radius_pkt_send(struct radius_t *this,
       struct radius_packet_t *pack,
       struct sockaddr_in *peer);
 
+#ifdef ENABLE_RADPROXY
+int radius_pkt_send_proxy(struct radius_t *this,
+      struct radius_packet_t *pack,
+      struct sockaddr_in *peer);
+#endif
+
 /* Send of a request */
 int radius_req(struct radius_t *this,
 	       struct radius_packet_t *pack,


### PR DESCRIPTION
The RADIUS proxy feature was broken because the response to the authenticator was sent through the RADIUS server socket (`(struct radius_t)::fd` instead of `(struct radius_t)::proxyfd`).

This bug was introduced in #236 (bfe0e4b024735482b2db6cd67e0c4d57cf38b9b3).