### PR TITLE
Fix macro expansion bug

### DIFF
--- a/src/redir.c
+++ b/src/redir.c
@@ -4034,8 +4034,9 @@ int redir_main(struct redir_t *redir,
           syslog(LOG_DEBUG, "%s(%d): handling Access-Reject", __FUNCTION__, __LINE__);
 
         if (!hasnexturl) {
-          if (_options.challengetimeout)
+          if (_options.challengetimeout) {
             redir_memcopy(REDIR_CHALLENGE);
+	  }
         } else {
           msg.mtype = REDIR_NOTYET;
         }


### PR DESCRIPTION
The macro redir_memcopy expands to multiple statements. However, one of
if-blocks where it is used lacks braces for the code block. This results
in parts of the macro being executed even if not intended and triggers
a compiler warning on modern GCC versions.