### PR TITLE
Fix session handling on DHCP NAK packets

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -5515,9 +5515,11 @@ int dhcp_relay_decaps(struct dhcp_t *this, int idx) {
     }
   }
 
-  if (conn->authstate == DHCP_AUTH_NONE ||
-      conn->authstate == DHCP_AUTH_DNAT)
+  if (message_type->v[0] != DHCPNAK &&
+      (conn->authstate == DHCP_AUTH_NONE ||
+       conn->authstate == DHCP_AUTH_DNAT)) {
     this->cb_request(conn, (struct in_addr *)&packet.yiaddr, 0, 0);
+  }
 
   packet.giaddr = 0;
 


### PR DESCRIPTION
The macro redir_memcopy expands to multiple statements. However, one of
if-blocks where it is used lacks braces for the code block. This results
in parts of the macro being executed even if not intended and triggers
a compiler warning on modern GCC versions.