### PR TITLE
system.h: Fix compilation with kernel 4.19 + musl

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -114,6 +114,7 @@
 
 #ifdef HAVE_SYS_SYSINFO_H
 #include <sys/sysinfo.h>
+#define _LINUX_SYSINFO_H
 #else
 #ifdef HAVE_LINUX_SYSINFO_H
 #define _LINUX_KERNEL_H


### PR DESCRIPTION
<linux/netlink.h> includes <linux/sysinfo.h> , which redefines struct sysinfo, leading to an error.
Define the linux header as included to solve compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>