### PR TITLE
docs: fix simple typo, tighest -> tightest

### DIFF
--- a/bstring/bstrlib.c
+++ b/bstring/bstrlib.c
@@ -114,7 +114,7 @@ balloc(bstring b, int olen)
 retry:
 			x = realloc(b->data, len);
 			if (x == NULL) {
-				/* Since we failed, try mallocating the tighest
+				/* Since we failed, try mallocating the tightest
 				 * possible mallocation
 				 */
 				len = olen;


### PR DESCRIPTION
There is a small typo in bstring/bstrlib.c.

Should read `tightest` rather than `tighest`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md