### PR TITLE
chilli: fix build with --enable-authedallowed

### DIFF
--- a/src/chilli.c
+++ b/src/chilli.c
@@ -5756,8 +5756,10 @@ int chilli_acct_fromsub(struct app_conn_t *appconn,
       /*
        *  Change to garden accounting.
        */
+#ifdef ENABLE_GARDENACCOUNTING
       if (_options.nousergardendata)
 	is_garden = 1;
+#endif
 #ifdef ENABLE_LEAKYBUCKET
       do_bw = 0;
       if (_options.debug)
@@ -5883,8 +5885,10 @@ int chilli_acct_tosub(struct app_conn_t *appconn,
       /*
        *  Change to garden accounting.
        */
+#ifdef ENABLE_GARDENACCOUNTING
       if (_options.nousergardendata)
 	is_garden = 1;
+#endif
 #ifdef ENABLE_LEAKYBUCKET
       do_bw = 0;
 #endif


### PR DESCRIPTION
The nousergardendata in the options struct is only defined if garden
accounting is also enabled.