### PR TITLE
xt_coova: fix compile with kernel>=5.17

### DIFF
--- a/src/linux/xt_coova.c
+++ b/src/linux/xt_coova.c
@@ -467,7 +467,9 @@ static int coova_seq_open(struct inode *inode, struct file *file)
 	if (st == NULL)
 		return -ENOMEM;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
+	st->table = pde_data(inode);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
 	st->table = PDE_DATA(inode);
 #else
 	st->table = pde->data;
@@ -479,7 +481,9 @@ static ssize_t
 coova_mt_proc_write(struct file *file, const char __user *input,
 		    size_t size, loff_t *loff)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
+	struct coova_table *t = pde_data(file_inode(file));
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
 	struct coova_table *t = PDE_DATA(file_inode(file));
 #else
 	const struct proc_dir_entry *pde = PDE(file->f_path.dentry->d_inode);


### PR DESCRIPTION
Linux kernel 5.17 removed PDE_DATA, and replaced it with pde_data [0]

[0]: https://github.com/torvalds/linux/commit/359745d78351c6f5442435f81549f0207ece28aa

Signed-off-by: John Thomson <git@johnthomson.fastmail.com.au>