### PR TITLE
fix for getting fragment offset in ip header

### DIFF
--- a/src/pkt.h
+++ b/src/pkt.h
@@ -173,7 +173,7 @@ struct pkt_iphdr_t {
 
 #define iphdr_dont_frag(p) ((p)->opt_off_high & 0x40)
 #define iphdr_more_frag(p) ((p)->opt_off_high & 0x20)
-#define iphdr_offset(p) ntohs((((p)->opt_off_high & 0x13) << 8)|(p)->off_low)
+#define iphdr_offset(p) ntohs((((p)->opt_off_high & 0xf8) << 8)|(p)->off_low)
 
 #ifdef ENABLE_IPV6
 #define PKT_IPv6_ALEN 16

--- a/src/pkt.h
+++ b/src/pkt.h
@@ -173,7 +173,7 @@ struct pkt_iphdr_t {
 
 #define iphdr_dont_frag(p) ((p)->opt_off_high & 0x40)
 #define iphdr_more_frag(p) ((p)->opt_off_high & 0x20)
-#define iphdr_offset(p) ntohs((((p)->opt_off_high & 0xf8) << 8)|(p)->off_low)
+#define iphdr_offset(p) ntohs((((p)->opt_off_high & 0x1f) << 8)|(p)->off_low)
 
 #ifdef ENABLE_IPV6
 #define PKT_IPv6_ALEN 16


### PR DESCRIPTION
In an IP header, If the first 3 bits from the 7th byte are flags not related to the fragment offset, then they should be blocked out (using bitwise &) and the rest should remain, hence:

`ntohs((((p)->opt_off_high & 0x1f) << 8)|(p)->off_low)`

In the original:

`ntohs((((p)->opt_off_high & 0x13) << 8)|(p)->off_low)`

I'm really having trouble understanding why we `&` with `0x13`, won't this unset some of the fragmentation offset bits?

Maybe this is something I don't understand (I'm new to low level network programming), if so, please let me know why it's done this way.

Thanks