### PR TITLE
src/dns.c: add QTYPE 65 (HTTPS/SVCB) in dns_copy_res()

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -422,6 +422,10 @@ dns_copy_res(struct dhcp_conn_t *conn, int q,
       if (_options.debug)
         syslog(LOG_DEBUG, "%s(%d): NSEC record", __FUNCTION__, __LINE__);
       break;
+    case 65:
+      if (_options.debug)
+        syslog(LOG_DEBUG, "%s(%d): HTTPS (SVCB) record", __FUNCTION__, __LINE__);
+      break;    
   }
 
   if (antidnstunnel && !required) {


### PR DESCRIPTION
When running Coova-Chilli on OpenWrt, DNS queries of type 65 (HTTPS/SVCB, used for DNS-over-HTTPS bootstrap) currently fall through the parser’s default case and trigger repeated warnings:

- packet dump:
`wlp3s0f0 Out IP 192.168.182.5.35526 > 1.1.1.3.53: 62032+ [1au] HTTPS? cloudflare-dns.com.`
- log: 
`daemon.warn chilli[22249]: dropping malformed DNS`

This pull request adds a case 65 branch inside dns_copy_res(), so that QTYPE 65 is correctly recognized as an HTTPS/SVCB record and no longer triggers the “dropping malformed DNS” warning.

Signed-off-by: Valerio Montagliani valeriomail3@gmail.com