### PR TITLE
Fix UAM challenge race by issuing challenges in the main daemon

### DIFF
--- a/src/chilli.c
+++ b/src/chilli.c
@@ -7114,6 +7114,73 @@ int chilli_io(int fd_ctrl_r, int fd_ctrl_w, int fd_pkt_r, int fd_pkt_w) {
 #endif
 
 #ifdef USING_IPC_UNIX
+static int uam_ensure_challenge_reply(int sock, struct redir_msg_t *msg) {
+  struct ippoolm_t *ipm;
+  struct app_conn_t *appconn = NULL;
+  struct redir_conn_t outconn;
+  long req = msg->mtype;
+  int policy = (int)(req - REDIR_MSG_ENSURE_CHALLENGE_PRELOGIN);
+  time_t timenow = mainclock_now();
+  int need = 0;
+
+  if (req < REDIR_MSG_ENSURE_CHALLENGE_PRELOGIN ||
+      req > REDIR_MSG_ENSURE_CHALLENGE_ALWAYS)
+    return -1;
+
+#if defined(HAVE_NETFILTER_QUEUE) || defined(HAVE_NETFILTER_COOVA)
+  if (_options.uamlisten.s_addr != _options.dhcplisten.s_addr) {
+    msg->mdata.address.sin_addr.s_addr =
+        msg->mdata.address.sin_addr.s_addr & ~(_options.mask.s_addr);
+    msg->mdata.address.sin_addr.s_addr |=
+        _options.dhcplisten.s_addr & _options.mask.s_addr;
+  }
+#endif
+
+  if (ippool_getip(ippool, &ipm, &msg->mdata.address.sin_addr))
+    return -1;
+
+  if ((appconn = (struct app_conn_t *)ipm->peer) == NULL ||
+      appconn->dnlink == NULL)
+    return -1;
+
+  switch (policy) {
+  case 0:
+    need = !appconn->s_state.uamtime ||
+      (_options.challengetimeout &&
+       (appconn->s_state.uamtime + _options.challengetimeout) < timenow);
+    break;
+  case 1:
+    need = _options.challengetimeout &&
+      (appconn->s_state.uamtime + _options.challengetimeout) < timenow;
+    break;
+  case 2:
+    need = _options.challengetimeout2 &&
+      (appconn->s_state.uamtime + _options.challengetimeout2) < timenow;
+    break;
+  case 3:
+    need = 1;
+    break;
+  default:
+    return -1;
+  }
+
+  if (!_options.nochallenge && need) {
+    if (uam_random_challenge(appconn->s_state.redir.uamchal, REDIR_MD5LEN))
+      return -1;
+    appconn->s_state.uamtime = mainclock.tv_sec;
+    appconn->uamabort = 0;
+  }
+
+  memset(&outconn, 0, sizeof(outconn));
+  if (cb_redir_getstate(redir, &msg->mdata.address, &msg->mdata.baddress,
+                        &outconn) == -1)
+    return -1;
+
+  if (safe_write(sock, &outconn, sizeof(outconn)) != (ssize_t)sizeof(outconn))
+    return -1;
+  return 0;
+}
+
 int static redir_msg(struct redir_t *this) {
   struct redir_msg_t msg;
   struct sockaddr_un remote;
@@ -7133,6 +7200,10 @@ int static redir_msg(struct redir_t *this) {
 	    syslog(LOG_ERR, "%s: redir_msg writing", strerror(errno));
 	  }
 	}
+      } else if (msg.mtype >= REDIR_MSG_ENSURE_CHALLENGE_PRELOGIN &&
+		 msg.mtype <= REDIR_MSG_ENSURE_CHALLENGE_ALWAYS) {
+	if (uam_ensure_challenge_reply(socket, &msg) < 0 && _options.debug)
+	  syslog(LOG_DEBUG, "%s: ensure challenge reply failed", __FUNCTION__);
       } else {
 	uam_msg(&msg);
       }

--- a/src/chilli.h
+++ b/src/chilli.h
@@ -332,6 +332,7 @@ int runscript(struct app_conn_t *appconn, char* script,
 
 /* utils.c */
 int statedir_file(char *dst, int dlen, char *file, char *deffile);
+int uam_random_challenge(uint8_t *dst, size_t len);
 int bblk_fromfd(bstring s, int fd, int len);
 int bstring_fromfd(bstring s, int fd);
 #ifndef HAVE_GETLINE

--- a/src/redir.c
+++ b/src/redir.c
@@ -3324,6 +3324,72 @@ int redir_send_msg(struct redir_t *this, struct redir_msg_t *msg) {
   safe_close(s);
   return 0;
 }
+
+/*
+ * Ask the main chilli daemon to create or reuse the UAM challenge for this
+ * subscriber (serialized in the daemon).  Replies with a full redir_conn_t
+ * snapshot like REDIR_MSG_STATUS_TYPE.
+ */
+static int redir_ensure_challenge_rpc(struct redir_t *this,
+				      struct sockaddr_in *address,
+				      struct sockaddr_in *baddress,
+				      struct redir_conn_t *conn,
+				      long mtype_req) {
+  struct redir_msg_t msg;
+  struct sockaddr_un remote;
+  size_t len = sizeof(remote);
+  int s;
+  char filedest[512];
+
+  (void)this;
+
+  memset(&msg, 0, sizeof(msg));
+  msg.mtype = mtype_req;
+  memcpy(&msg.mdata.address, address, sizeof(*address));
+  memcpy(&msg.mdata.baddress, baddress, sizeof(*baddress));
+
+  statedir_file(filedest, sizeof(filedest), _options.unixipc, "chilli.ipc");
+
+  if ((s = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
+    syslog(LOG_ERR, "%s: socket()", __FUNCTION__);
+    return -1;
+  }
+
+  memset(&remote, 0, sizeof(remote));
+  remote.sun_family = AF_UNIX;
+  strlcpy(remote.sun_path, filedest, sizeof(remote.sun_path));
+
+#if defined (__FreeBSD__)  || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__)
+  remote.sun_len = strlen(remote.sun_path) + 1;
+#endif
+
+  len = offsetof(struct sockaddr_un, sun_path) + strlen(remote.sun_path);
+
+  if (safe_connect(s, (struct sockaddr *)&remote, len) == -1) {
+    syslog(LOG_ERR, "%s: could not connect to %s", strerror(errno),
+	   remote.sun_path);
+    safe_close(s);
+    return -1;
+  }
+
+  if (safe_write(s, &msg, sizeof(msg)) != sizeof(msg)) {
+    syslog(LOG_ERR, "%s: could not write to %s", strerror(errno),
+	   remote.sun_path);
+    safe_close(s);
+    return -1;
+  }
+
+  if (safe_read(s, conn, sizeof(*conn)) != sizeof(*conn)) {
+    syslog(LOG_ERR, "%s: short read from %s", strerror(errno),
+	   remote.sun_path);
+    safe_close(s);
+    return -1;
+  }
+
+  shutdown(s, 2);
+  safe_close(s);
+  return 0;
+}
 #endif
 
 pid_t redir_fork(int in, int out) {
@@ -3458,6 +3524,25 @@ int redir_main(struct redir_t *redir,
            strerror(errno), redir->msgid, msg.mtype, (int)sizeof(msg.mdata)); \
     return redir_main_exit(&socket, forked, rreq);                      \
   }
+#endif
+
+#ifdef USING_IPC_UNIX
+#define redir_uam_challenge_via_daemon(pol)				\
+  do {									\
+    if (redir_ensure_challenge_rpc(redir, address, baddress, &conn,	\
+				   (pol)) < 0)				\
+      return redir_main_exit(&socket, forked, rreq);			\
+    redir_chartohex(conn.s_state.redir.uamchal, hexchal, REDIR_MD5LEN); \
+    msg.mtype = REDIR_CHALLENGE;					\
+    redir_msg_send(REDIR_MSG_OPT_REDIR);				\
+  } while (0)
+#else
+#define redir_uam_challenge_via_daemon(pol)				\
+  do {									\
+    (void)(pol);							\
+    redir_memcopy(REDIR_CHALLENGE);					\
+    redir_msg_send(REDIR_MSG_OPT_REDIR);				\
+  } while (0)
 #endif
 
   /*
@@ -3992,18 +4077,33 @@ int redir_main(struct redir_t *redir,
       if (_options.challengetimeout2 &&
           (conn.s_state.uamtime + _options.challengetimeout2) <
           mainclock_now()) {
+        int still_bad = 1;
+
         if (_options.debug)
           syslog(LOG_DEBUG, "%s(%d): redir_accept: challenge expired: %ld : %ld", __FUNCTION__, __LINE__,
                  (long) conn.s_state.uamtime, (long) mainclock_now());
 
-        redir_memcopy(REDIR_CHALLENGE);
-        redir_msg_send(REDIR_MSG_OPT_REDIR);
+#ifdef USING_IPC_UNIX
+        {
+          int _r = redir_ensure_challenge_rpc(redir, address, baddress, &conn,
+					      REDIR_MSG_ENSURE_CHALLENGE_LOGIN2);
+          if (_r < 0)
+            return redir_main_exit(&socket, forked, rreq);
+          if ((conn.s_state.uamtime + _options.challengetimeout2) >= mainclock_now())
+            still_bad = 0;
+        }
+#endif
 
-        redir_reply(redir, &socket, &conn, REDIR_FAILED_OTHER, NULL,
-                    0, hexchal, NULL, NULL, NULL,
-                    0, conn.hismac, &conn.hisip, httpreq.qs);
+        if (still_bad) {
+          redir_memcopy(REDIR_CHALLENGE);
+          redir_msg_send(REDIR_MSG_OPT_REDIR);
 
-        return redir_main_exit(&socket, forked, rreq);
+          redir_reply(redir, &socket, &conn, REDIR_FAILED_OTHER, NULL,
+                      0, hexchal, NULL, NULL, NULL,
+                      0, conn.hismac, &conn.hisip, httpreq.qs);
+
+          return redir_main_exit(&socket, forked, rreq);
+        }
       }
 
       if (is_local_user(redir, &conn)) {
@@ -4104,7 +4204,15 @@ int redir_main(struct redir_t *redir,
 
         if (!hasnexturl) {
           if (_options.challengetimeout) {
+#ifdef USING_IPC_UNIX
+            if (redir_ensure_challenge_rpc(redir, address, baddress, &conn,
+					   REDIR_MSG_ENSURE_CHALLENGE_ALWAYS) < 0)
+              return redir_main_exit(&socket, forked, rreq);
+            redir_chartohex(conn.s_state.redir.uamchal, hexchal, REDIR_MD5LEN);
+            msg.mtype = REDIR_CHALLENGE;
+#else
             redir_memcopy(REDIR_CHALLENGE);
+#endif
 	  }
         } else {
           msg.mtype = REDIR_NOTYET;
@@ -4153,8 +4261,7 @@ int redir_main(struct redir_t *redir,
           (_options.challengetimeout &&
            (conn.s_state.uamtime + _options.challengetimeout) <
            mainclock_now())) {
-        redir_memcopy(REDIR_CHALLENGE);
-        redir_msg_send(REDIR_MSG_OPT_REDIR);
+        redir_uam_challenge_via_daemon(REDIR_MSG_ENSURE_CHALLENGE_PRELOGIN);
       }
 
       if (state == 1) {
@@ -4204,8 +4311,7 @@ int redir_main(struct redir_t *redir,
         /* Did the challenge expire? */
         if (_options.challengetimeout &&
             (conn.s_state.uamtime + _options.challengetimeout) < timenow) {
-          redir_memcopy(REDIR_CHALLENGE);
-          redir_msg_send(REDIR_MSG_OPT_REDIR);
+          redir_uam_challenge_via_daemon(REDIR_MSG_ENSURE_CHALLENGE_STATUS);
         }
 
         sessiontime = timenow - conn.s_state.start_time;
@@ -4386,8 +4492,7 @@ int redir_main(struct redir_t *redir,
   if (!conn.s_state.uamtime ||
       (_options.challengetimeout &&
        (conn.s_state.uamtime + _options.challengetimeout) < mainclock_now())) {
-    redir_memcopy(REDIR_CHALLENGE);
-    redir_msg_send(REDIR_MSG_OPT_REDIR);
+    redir_uam_challenge_via_daemon(REDIR_MSG_ENSURE_CHALLENGE_PRELOGIN);
   }
   else {
     redir_chartohex(conn.s_state.redir.uamchal, hexchal, REDIR_MD5LEN);

--- a/src/redir.h
+++ b/src/redir.h
@@ -284,6 +284,11 @@ struct redir_msg_t {
 } __attribute__((packed));
 
 #define REDIR_MSG_STATUS_TYPE 1000
+/* RPC: daemon generates/refreshes UAM challenge (serialized, no lock files) */
+#define REDIR_MSG_ENSURE_CHALLENGE_PRELOGIN  1001
+#define REDIR_MSG_ENSURE_CHALLENGE_STATUS    1002
+#define REDIR_MSG_ENSURE_CHALLENGE_LOGIN2   1003
+#define REDIR_MSG_ENSURE_CHALLENGE_ALWAYS    1004
 
 int redir_md_param(bstring str, char *secret, char *amp);
 

--- a/src/util.c
+++ b/src/util.c
@@ -33,6 +33,22 @@ int statedir_file(char *dst, int dlen, char *file, char *deffile) {
   return 0;
 }
 
+int uam_random_challenge(uint8_t *dst, size_t len) {
+  FILE *f;
+
+  if ((f = fopen("/dev/urandom", "r")) == NULL) {
+    syslog(LOG_ERR, "%s: fopen(/dev/urandom): %s", __FUNCTION__, strerror(errno));
+    return -1;
+  }
+  if (fread(dst, 1, len, f) != len) {
+    syslog(LOG_ERR, "%s: fread(/dev/urandom)", __FUNCTION__);
+    fclose(f);
+    return -1;
+  }
+  fclose(f);
+  return 0;
+}
+
 int bblk_fromfd(bstring s, int fd, int len) {
   int blen = len > 0 ? len : 128;
   int rd, rlen=0;


### PR DESCRIPTION
**Summary**

Parallel `chilliredir` workers could each generate a different UAM challenge while the main daemon still had `uamtime == 0` (or before state was synchronized). The HTTP response seen by the client could then disagree with the challenge `stored` in chilli, leading to valid credentials but RADIUS Access-Reject (especially with CHAP). A retry often worked because a single code path then owned the session.

In my case, this represents approximately 5 to 10% of login attempts that result in an "Access-Reject".

The behavior seems to be related to the type of device being used; it is consistently reproducible with a Google Pixel 7a but not with an iPad, for example.

**Solution**

Challenge creation / refresh for the affected UAM paths is moved to the main chilli daemon, which already handles UAM IPC in a single-threaded way for each accepted connection. The redir side uses a new Unix-socket RPC (same pattern as `REDIR_MSG_STATUS_TYPE` / `redir_conn_t reply`): message types 1001–1004 encode the same policy as the previous `redir_memcopy(REDIR_CHALLENGE)` sites (prelogin/splash, status, `challengetimeout2`, and “always” on reject when `challengetimeout` is set).

Random bytes are read in the daemon via a small helper `uam_random_challenge()` in `util.c` (shared with the former redir-side `/dev/urandom` logic).