### PR TITLE
Add API URI (RFC 8910/8908) per-client placeholders ${t}

### DIFF
--- a/src/cmdline.ggo
+++ b/src/cmdline.ggo
@@ -289,7 +289,7 @@ option "forcedns1port"   - "Force all DNS to a specific port" int default="0" no
 option "forcedns2"   - "Force all secondary DNS to a specific address" string no 
 option "forcedns2port"   - "Force all secondary DNS to a specific port" int default="0" no 
 
-option "captiveportalapi_uri" - "DHCP Captive Portal API URI (RFC 8910/8908). HTTPS recommended. Optional per-client placeholders: %{m} MAC, %{M} MAC hex, %{i} client IPv4, %{n} NAS-ID (URL-encoded), %{s} Chilli session id (RADIUS Acct-Session-Id). Expanded URI must be <=255 bytes (DHCPv4). Only %{...} sequences are expanded; %XX stays as-is." string no
+option "captiveportalapi_uri" - "DHCP Captive Portal API URI (RFC 8910/8908). HTTPS recommended. Optional per-client placeholders: %{m} MAC, %{M} MAC hex, %{i} client IPv4, %{n} NAS-ID (URL-encoded), %{s} Chilli session id (RADIUS Acct-Session-Id), %{t} imestamp (seconds since Unix epoch) indicating when the API URL was assigned to the client in the DHCP lease. Expanded URI must be <=255 bytes (DHCPv4). Only %{...} sequences are expanded; %XX stays as-is." string no
 option "captiveportalvenue_info_url"  - "Venue info URL (RFC 8908)" string no
 
 option "ipv6" - "Enable IPv6 support" flag off

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -3202,6 +3202,15 @@ static int dhcp_expand_captiveportal_uri(struct dhcp_conn_t *conn,
 	    d += l;
 	  }
 	  break;
+	case 't':
+	  {
+	    time_t time_now = time(NULL);
+	    char time_now_string[32];
+	    snprintf(time_now_string, sizeof(time_now_string), "%ld", (long)time_now);
+	    memcpy(d, time_now_string, strlen(time_now_string));
+	    d += strlen(time_now_string);
+	  }
+	  break;
 	default:
 	  /* unknown %{x}: copy verbatim */
 	  goto copy_verbatim;

--- a/src/options.h
+++ b/src/options.h
@@ -322,7 +322,7 @@ struct options_t {
   uint32_t ipsrc_num_pass_throughs;
 #endif
 
-  char* captiveportalapi_uri; /* RFC 8910 API URI template; optional %{m},%{M},%{i},%{n},%{s} per client (RFC 8908). */
+  char* captiveportalapi_uri; /* RFC 8910 API URI template; optional %{m},%{M},%{i},%{n},%{s},%{t} per client (RFC 8908). */
 
   char* captiveportalvenue_info_url; /* RFC 8908 Captive Portal Venue Information URL, nullptr if not used. */
 


### PR DESCRIPTION
Add API URI (RFC 8910/8908) per-client placeholders ${t}, for a timestamp (seconds since Unix epoch) indicating when the API URL was assigned to the client in the DHCP lease.

This allows to detect when a client makes a new DHCP request, within the API code. This can be very useful to trigger special actions when the user disconnect and/or reconnect to a network, or change Wifi AP. While all other parameters can remain the same ( mac, ip, Chilli session id ), this parameter will change for every DHCP Offer.

It can be very useful for example if you want to trigger opening the captive portal, whenever the client connects/reconnects to the Wifi network, on physical layer.